### PR TITLE
Correcting APIC rest abstraction

### DIFF
--- a/connector/docs/changelog/undistributed.rst
+++ b/connector/docs/changelog/undistributed.rst
@@ -7,6 +7,7 @@
 
 Features:
 ^^^^^^^^^
+* Moved APIC implementation from NXOS/ACI to APIC
 
 * IOSXE
     * Added sshtunnel support

--- a/connector/src/rest/connector/libs/apic/__init__.py
+++ b/connector/src/rest/connector/libs/apic/__init__.py
@@ -1,0 +1,7 @@
+# Enable abstraction using this directory name as the abstraction token
+try:
+    from genie import abstract
+    abstract.declare_token(__name__)
+except Exception as e:
+    import warnings
+    warnings.warn('Could not declare abstraction token: ' + str(e))

--- a/connector/src/rest/connector/libs/apic/implementation.py
+++ b/connector/src/rest/connector/libs/apic/implementation.py
@@ -43,14 +43,6 @@ class Implementation(Imp):
         >>> device.rest.connected
         True
     '''
-    def __init__(self, *args, **kwargs):
-        import warnings
-        warnings.warn(
-            "This rest.connector library is deprecated and will be removed "
-            "on v20.3. Please set your testbed to 'os: apic' in order to "
-            "use the new library.")
-
-        super().__init__(*args, **kwargs)
 
     @BaseConnection.locked
     def connect(self, timeout=30):


### PR DESCRIPTION
/nxos/aci to /apic