### PR TITLE
Add target_subtree_class query parameter to APIC

### DIFF
--- a/docs/user_guide/services/apic.rst
+++ b/docs/user_guide/services/apic.rst
@@ -44,6 +44,9 @@ API to send GET command to the device.
     * - query_target_filter (string)
       - filter expression
       - None
+    * - target_subtree_class (string)
+      - specify class
+      - None
     * - expected_status_code (int)
       - Expected result
       - None

--- a/src/rest/connector/libs/apic/implementation.py
+++ b/src/rest/connector/libs/apic/implementation.py
@@ -181,6 +181,7 @@ class Implementation(Imp):
     def get(self, dn, query_target='self', rsp_subtree='no', \
             query_target_filter='', rsp_prop_include='all', \
             rsp_subtree_include='', rsp_subtree_class='',\
+            target_subtree_class='',\
             expected_status_code=requests.codes.ok, timeout=30):
         '''GET REST Command to retrieve information from the device
 
@@ -208,6 +209,7 @@ class Implementation(Imp):
             rsp_subtree_include (string): specify additional contained objects 
                                           or options to be included
             rsp_subtree_class (string) : specify classes
+            target_subtree_class (string): specify subtree classes
             query_target_filter (string): filter expression
             expected_status_code (int): Expected result
         '''
@@ -235,6 +237,10 @@ class Implementation(Imp):
         if rsp_subtree_class:
             full_url += "&rsp-subtree-class={rsc}"\
                 .format(rsc=rsp_subtree_class)
+
+        if target_subtree_class:
+            full_url += "&target-subtree-class={tsc}"\
+                .format(tsc=target_subtree_class)
 
         log.info("Sending GET command to '{d}':"\
                  "\nDN: {furl}".format(d=self.device.name, furl=full_url))


### PR DESCRIPTION
This PR adds support for the "target_subtree_class" query parameter in the APIC REST connector