### PR TITLE
Fix BigIP implementation

### DIFF
--- a/src/rest/connector/tests/test_apic.py
+++ b/src/rest/connector/tests/test_apic.py
@@ -19,6 +19,13 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['apic']
+        # Always mock logging
+        mock_logger = patch(
+            "rest.connector.libs.apic.implementation.log"
+        )
+        self.mock_logger: MagicMock = mock_logger.start()
+        self.addCleanup(mock_logger.stop)
+
 
     def test_init(self):
         connection = Rest(device=self.device, alias='rest', via='rest')
@@ -58,8 +65,8 @@ class test_rest_connector(unittest.TestCase):
 
         with patch('requests.Session') as req:
             resp = Response()
-            resp.status_code = [404, 404, 404]
-            req().post.return_value = resp
+            resp.status_code = 404
+            req.return_value.post.return_value = resp
 
             with self.assertRaises(ConnectionError):
                 connection.connect(retry_wait=1)

--- a/src/rest/connector/tests/test_iosxe.py
+++ b/src/rest/connector/tests/test_iosxe.py
@@ -562,7 +562,7 @@ All rights reserved.
                 </body>
             </html>
 """
-        kwargs['mock'].get('https://1.2.3.4:443/', text=response_text)
+        kwargs['mock'].get('https://198.51.100.3:443/', text=response_text)
         output = connection.connect(verbose=True).text
         self.assertEqual(output, response_text)
         return connection
@@ -602,7 +602,7 @@ All rights reserved.
 }
 """
 
-        kwargs['mock'].get('https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile', text=response_text)
+        kwargs['mock'].get('https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile', text=response_text)
         output = connection.get('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile', verbose=True).text
         self.assertEqual(output, response_text)
         connection.disconnect()
@@ -643,7 +643,7 @@ All rights reserved.
     }
 }
 """
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].post(url, status_code=204)
         output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
         self.assertEqual(output, '')
@@ -686,7 +686,7 @@ All rights reserved.
 }
         response_text = ""
 
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].post(url, text=response_text)
         try:
             output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, verbose=True).text
@@ -728,7 +728,7 @@ All rights reserved.
         }
     }
 }
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].post(url, status_code=204)
         try:
             output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
@@ -770,7 +770,7 @@ All rights reserved.
         }
     }
 }
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].post(url, status_code=204)
         try:
             output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='xml', verbose=True).text
@@ -812,7 +812,7 @@ All rights reserved.
     }
 }
 """
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
         kwargs['mock'].patch(url, status_code=204)
         output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='json', verbose=True).text
         self.assertEqual(output, '')
@@ -853,7 +853,7 @@ All rights reserved.
 }
         response_text = ""
 
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
         kwargs['mock'].patch(url, text=response_text)
         try:
             output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, verbose=True).text
@@ -895,7 +895,7 @@ All rights reserved.
         }
     }
 }
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
         kwargs['mock'].patch(url, status_code=204)
         try:
             output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='json', verbose=True).text
@@ -935,7 +935,7 @@ All rights reserved.
         }
     }
 }
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
         kwargs['mock'].patch(url, status_code=204)
         try:
             output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='xml', verbose=True).text
@@ -979,7 +979,7 @@ All rights reserved.
     }
 }
 """
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].put(url, status_code=204)
         output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
         self.assertEqual(output, '')
@@ -1022,7 +1022,7 @@ All rights reserved.
 }
         response_text = ""
 
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].put(url, text=response_text)
         try:
             output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, verbose=True).text
@@ -1064,7 +1064,7 @@ All rights reserved.
         }
     }
 }
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].put(url, status_code=204)
         try:
             output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
@@ -1106,7 +1106,7 @@ All rights reserved.
         }
     }
 }
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
         kwargs['mock'].put(url, status_code=204)
         try:
             output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='xml', verbose=True).text
@@ -1120,7 +1120,7 @@ All rights reserved.
     def test_delete(self, **kwargs):
         connection = self.test_connect()
 
-        url = 'https://1.2.3.4:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=test-profile'
+        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=test-profile'
         kwargs['mock'].delete(url, status_code=204)
         output = connection.delete('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=test-profile', verbose=True).text
         self.assertEqual(output, '')

--- a/src/rest/connector/tests/test_nd.py
+++ b/src/rest/connector/tests/test_nd.py
@@ -18,6 +18,12 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['nd']
+        # Always mock logging
+        mock_logger = patch(
+            "rest.connector.libs.nd.implementation.log"
+        )
+        self.mock_logger: MagicMock = mock_logger.start()
+        self.addCleanup(mock_logger.stop)
 
     def test_init(self):
         connection = Rest(device=self.device, alias='rest', via='rest')

--- a/src/rest/connector/tests/test_nso.py
+++ b/src/rest/connector/tests/test_nso.py
@@ -35,7 +35,7 @@ class test_nso_test_connector(unittest.TestCase):
 </api>
 """
 
-        kwargs['mock'].get('http://1.2.3.4:8080/api', text=response_text)
+        kwargs['mock'].get('http://198.51.100.2:8080/api', text=response_text)
         output = connection.connect(verbose=True).text
         self.assertEqual(output, response_text)
         return connection
@@ -89,7 +89,7 @@ class test_nso_test_connector(unittest.TestCase):
 }
 """
 
-        kwargs['mock'].get('http://1.2.3.4:8080/api/running/devices', text=response_text)
+        kwargs['mock'].get('http://198.51.100.2:8080/api/running/devices', text=response_text)
         output = connection.get('/api/running/devices', verbose=True).text
         self.assertEqual(output, response_text)
         connection.disconnect()
@@ -107,7 +107,7 @@ class test_nso_test_connector(unittest.TestCase):
 """
 
         url = '/api/running/devices/device/R1/_operations/check-sync'
-        kwargs['mock'].post('http://1.2.3.4:8080%s' % url, text=response_text)
+        kwargs['mock'].post('http://198.51.100.2:8080%s' % url, text=response_text)
         output = connection.post(url, content_type='xml', verbose=True).text
         self.assertEqual(output, response_text)
         connection.disconnect()
@@ -127,7 +127,7 @@ class test_nso_test_connector(unittest.TestCase):
 """
 
         url = '/api/running/devices/device/R1/_operations/check-sync'
-        kwargs['mock'].post('http://1.2.3.4:8080%s' % url, text=response_text)
+        kwargs['mock'].post('http://198.51.100.2:8080%s' % url, text=response_text)
         try:
             output = connection.post(url, payload, verbose=True).text
         except AssertionError as e:
@@ -148,7 +148,7 @@ class test_nso_test_connector(unittest.TestCase):
 """
 
         url = '/api/running/devices/device/R1/_operations/check-sync'
-        kwargs['mock'].post('http://1.2.3.4:8080%s' % url, text=response_text)
+        kwargs['mock'].post('http://198.51.100.2:8080%s' % url, text=response_text)
         try:
             output = connection.post(url, payload, content_type='json', verbose=True).text
         except AssertionError as e:
@@ -170,7 +170,7 @@ class test_nso_test_connector(unittest.TestCase):
 """
 
         url = '/api/running/devices/device/R1/_operations/check-sync'
-        kwargs['mock'].post('http://1.2.3.4:8080%s' % url, text=response_text)
+        kwargs['mock'].post('http://198.51.100.2:8080%s' % url, text=response_text)
         try:
             output = connection.post(url, payload, content_type='xml', verbose=True).text
         except AssertionError as e:
@@ -199,7 +199,7 @@ class test_nso_test_connector(unittest.TestCase):
 """
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].patch('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].patch('http://198.51.100.2:8080%s' % url, status_code=204)
         output = connection.patch(url, payload, verbose=True).text
         self.assertEqual(output, '')
         connection.disconnect()
@@ -223,7 +223,7 @@ class test_nso_test_connector(unittest.TestCase):
         }
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].patch('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].patch('http://198.51.100.2:8080%s' % url, status_code=204)
         try:
             output = connection.patch(url, payload, verbose=True).text
         except AssertionError as e:
@@ -249,7 +249,7 @@ class test_nso_test_connector(unittest.TestCase):
         }
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].patch('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].patch('http://198.51.100.2:8080%s' % url, status_code=204)
         output = connection.patch(url, payload, content_type='json', verbose=True).text
         self.assertEqual(output, '')
         connection.disconnect()
@@ -273,7 +273,7 @@ class test_nso_test_connector(unittest.TestCase):
         }
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].patch('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].patch('http://198.51.100.2:8080%s' % url, status_code=204)
         output = connection.patch(url, payload, content_type='xml', verbose=True).text
         self.assertEqual(output, '')
         connection.disconnect()
@@ -304,7 +304,7 @@ class test_nso_test_connector(unittest.TestCase):
 """
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].put('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].put('http://198.51.100.2:8080%s' % url, status_code=204)
         output = connection.put(url, payload, verbose=True).text
         self.assertEqual(output, '')
         connection.disconnect()
@@ -333,7 +333,7 @@ class test_nso_test_connector(unittest.TestCase):
         }
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].put('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].put('http://198.51.100.2:8080%s' % url, status_code=204)
         try:
             output = connection.put(url, payload, verbose=True).text
         except AssertionError as e:
@@ -364,7 +364,7 @@ class test_nso_test_connector(unittest.TestCase):
         }
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].put('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].put('http://198.51.100.2:8080%s' % url, status_code=204)
         output = connection.put(url, payload, content_type='json', verbose=True).text
         connection.disconnect()
 
@@ -392,7 +392,7 @@ class test_nso_test_connector(unittest.TestCase):
         }
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].put('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].put('http://198.51.100.2:8080%s' % url, status_code=204)
         output = connection.put(url, payload, content_type='xml', verbose=True).text
         connection.disconnect()
 
@@ -404,7 +404,7 @@ class test_nso_test_connector(unittest.TestCase):
         connection = self.test_connect()
 
         url = '/api/running/devices/device/R1/config/ios:ip/route'
-        kwargs['mock'].delete('http://1.2.3.4:8080%s' % url, status_code=204)
+        kwargs['mock'].delete('http://198.51.100.2:8080%s' % url, status_code=204)
         output = connection.delete(url, verbose=True).text
         self.assertEqual(output, '')
         connection.disconnect()

--- a/src/rest/connector/tests/testbed.yaml
+++ b/src/rest/connector/tests/testbed.yaml
@@ -9,7 +9,7 @@ devices:
     connections:
       rest:
         class: rest.connector.Rest
-        ip: 1.2.3.4
+        ip: 198.51.100.1
   ncs:
       os: nso
       type: nso
@@ -20,7 +20,7 @@ devices:
         rest:
           class: rest.connector.Rest
           protocol: http
-          ip: 1.2.3.4
+          ip: 198.51.100.2
           port: 8080
           username: cisco
           password: cisco
@@ -34,7 +34,7 @@ devices:
           rest:
             class: rest.connector.Rest
             protocol: https
-            ip: 1.2.3.4
+            ip: 198.51.100.3
             port: 443
             username: cisco
             password: cisco
@@ -48,12 +48,12 @@ devices:
         rest:
           class: rest.connector.Rest
           protocol: http
-          ip: 1.2.3.4
+          ip: 198.51.100.4
           username: cisco
           password: cisco
         cobra:
           class: rest.connector.Acisdk
-          ip: 1.2.3.4
+          ip: 198.51.100.5
           username: cisco
           password: cisco
   nd:
@@ -66,7 +66,7 @@ devices:
       rest:
         class: rest.connector.Rest
         protocol: http
-        ip: 1.2.3.4
+        ip: 198.51.100.6
         username: cisco
         password: cisco
   bigip01.lab.local:
@@ -80,7 +80,7 @@ devices:
       rest:
         class: rest.connector.Rest
         protocol: https
-        ip: 1.2.3.4
+        ip: 198.51.100.7
         credentials:
           rest:
             username: admin
@@ -95,7 +95,7 @@ devices:
         rest:
           class: rest.connector.Rest
           protocol: http
-          ip: 1.2.3.4
+          ip: 198.51.100.8
           credentials:
             rest:
               username: admin
@@ -110,18 +110,19 @@ devices:
       rest:
         class: rest.connector.Rest
         protocol: http
-        ip: 1.2.3.4
+        ip: 198.51.100.9
         credentials:
           rest:
             token: webexaccesstoken
   elasticsearch:
     os: elasticsearch
+    type: elasticsearch
     connections:
       defaults:
         via: rest
       rest:
         class: rest.connector.Rest
-        ip: 1.2.3.4
+        ip: 198.51.100.10
         port: 9200
         protocol: http
 


### PR DESCRIPTION
* Fix regressions in BigIP implementation introduced in PR28 (partially fixed in PR65)
* Improve BigIP implementation connection handling (retries, conn checking, disconnect, etc...)
* Implement unit tests for BigIP implementation logic
* Update tests to use RFC5737 addresses for testing to protect from bad patching
* Small fixups in multiple unit tests (broken testbed, mock logger, etc...)