### PR TITLE
added order-by support to GET operation

### DIFF
--- a/docs/changelog/2022/january.rst
+++ b/docs/changelog/2022/january.rst
@@ -1,0 +1,24 @@
+January 2022
+============
+
+January 25
+----------
+
++-------------------------------+-------------------------------+
+| Module                        | Versions                      |
++===============================+===============================+
+| ``rest.connector ``           | 22.1                          |
++-------------------------------+-------------------------------+
+
+Upgrade Instructions
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    pip install --upgrade rest.connector
+
+
+Features:
+^^^^^^^^^
+* APIC
+    * Added order_by argument to GET operation

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -4,6 +4,7 @@ Changelog
 .. toctree::
    :maxdepth: 2
 
+   2022/january
    2021/december
    2021/october
    2021/september

--- a/docs/user_guide/services/apic/rest.rst
+++ b/docs/user_guide/services/apic/rest.rst
@@ -47,6 +47,9 @@ API to send GET command to the device.
     * - target_subtree_class (string)
       - specify class
       - None
+    * - order_by (string)
+      - sort the query response by one or more properties of a class
+      - None
     * - expected_status_code (int)
       - Expected result
       - None

--- a/src/rest/connector/libs/apic/implementation.py
+++ b/src/rest/connector/libs/apic/implementation.py
@@ -197,7 +197,7 @@ class Implementation(Imp):
     def get(self, dn, query_target='self', rsp_subtree='no', \
             query_target_filter='', rsp_prop_include='all', \
             rsp_subtree_include='', rsp_subtree_class='',\
-            target_subtree_class='',\
+            target_subtree_class='', order_by='', \
             expected_status_code=requests.codes.ok, timeout=30):
         '''GET REST Command to retrieve information from the device
 
@@ -227,6 +227,8 @@ class Implementation(Imp):
             rsp_subtree_class (string) : specify classes
             target_subtree_class (string): specify subtree classes
             query_target_filter (string): filter expression
+            order_by (string): sort the query response by one or 
+                               more properties of a class
             expected_status_code (int): Expected result
         '''
 
@@ -257,6 +259,10 @@ class Implementation(Imp):
         if target_subtree_class:
             full_url += "&target-subtree-class={tsc}"\
                 .format(tsc=target_subtree_class)
+
+        if order_by:
+            full_url += "&order-by={ob}"\
+                .format(ob=order_by)
 
         log.info("Sending GET command to '{d}':"\
                  "\nDN: {furl}".format(d=self.device.name, furl=full_url))


### PR DESCRIPTION
added order-by support to GET operation for APIC

ref: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/2-x/rest_cfg/2_1_x/b_Cisco_APIC_REST_API_Configuration_Guide/b_Cisco_APIC_REST_API_Configuration_Guide_chapter_01.html