### PR TITLE
Added content_type (json / xml / form) parameter to post and put

### DIFF
--- a/docs/changelog/undistributed/changelog_nd_20220804143330.rst
+++ b/docs/changelog/undistributed/changelog_nd_20220804143330.rst
@@ -1,0 +1,4 @@
+* Nexus Dashboard (ND)
+  * Added content_type parameter to post and put api
+  * Prevented an error from being raised if response does not contain a json,
+    thus returning more info to the user

--- a/docs/user_guide/services/nd.rst
+++ b/docs/user_guide/services/nd.rst
@@ -59,6 +59,9 @@ API to send POST command to the device.
     * - expected_status_code (int)
       - Expected result
       - 200
+    * - content_type
+      - (json / xml / form) Information about the type of request
+      - json
     * - timeout (int)
       - Maximum time it can take to disconnect to the device
       - 30 seconds
@@ -103,6 +106,9 @@ API to send PUT command to the device.
     * - expected_status_code (int)
       - Expected result
       - 200
+    * - content_type
+      - (json / xml / form) Information about the type of request
+      - json
     * - timeout (int)
       - Maximum time it can take to disconnect to the device
       - 30 seconds

--- a/src/rest/connector/tests/test_nd.py
+++ b/src/rest/connector/tests/test_nd.py
@@ -157,6 +157,72 @@ class test_rest_connector(unittest.TestCase):
             connection.disconnect()
         self.assertEqual(connection.connected, False)
 
+    def test_post_xml_dict_payload_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            connection.connect()
+            resp.json = MagicMock(return_value={'imdata': []})
+
+            with self.assertRaises(ValueError):
+                connection.post(api_url='temp', content_type='xml',
+                                payload={'payload': 'something'})
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
+    def test_post_xml_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            connection.connect()
+            resp._content = '<?xml version="1.0" encoding="UTF-8"?>' \
+                            '<imdata totalCount="0"></imdata>'
+
+            connection.post(api_url='temp', content_type='xml',
+                            payload='<fvTenant name="ExampleCorp"/>')
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
+    def test_post_form_dict_payload_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            req().put.text = 'Operation is successful'
+            connection.connect()
+
+            connection.post(api_url='temp', content_type='form',
+                            payload={'payload': 'something'})
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
+    def test_post_form_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            req().put.text = 'Operation is successful'
+            connection.connect()
+
+            connection.post(api_url='temp', content_type='form',
+                            payload='Form%20Data')
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
     def test_put_not_connected(self):
         connection = Rest(device=self.device, alias='rest', via='rest')
         with self.assertRaises(Exception):
@@ -241,6 +307,76 @@ class test_rest_connector(unittest.TestCase):
                 connection.put(api_url='temp', payload={'payload':'something'},
                                expected_status_code=400)
             self.assertEqual(connection.connected, True)
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
+    def test_put_xml_dict_payload_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            req().put.return_value = resp
+            connection.connect()
+            resp.json = MagicMock(return_value={'imdata': []})
+
+            with self.assertRaises(ValueError):
+                connection.put(api_url='temp', content_type='xml',
+                               payload={'payload': 'something'})
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
+    def test_put_xml_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            req().put.return_value = resp
+            connection.connect()
+            resp._content = '<?xml version="1.0" encoding="UTF-8"?>' \
+                            '<imdata totalCount="0"></imdata>'
+
+            connection.put(api_url='temp', content_type='xml',
+                           payload='<fvTenant name="ExampleCorp"/>')
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
+    def test_put_form_dict_payload_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            req().put.return_value = resp
+            req().put.text = 'Operation is successful'
+            connection.connect()
+
+            connection.put(api_url='temp', content_type='form',
+                           payload={'payload': 'something'})
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)
+
+    def test_put_form_connected(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            req().put.return_value = resp
+            req().put.text = 'Operation is successful'
+            connection.connect()
+
+            connection.put(api_url='temp', content_type='form',
+                           payload='Form%20Data')
             connection.disconnect()
         self.assertEqual(connection.connected, False)
 


### PR DESCRIPTION
Added content_type (json / xml / form) parameter to post and put functions.
Changed operation order in the delete function:
 - the response (json / text) is processed and logged
 - status code is verified - more information is now available to the user in case of an unexpected status code
Prevented the code from raising an error when output data is not in JSON format