### PR TITLE
removed genie dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,6 @@ setup(
         'requests >= 1.15.1',
         'dict2xml',
         'f5-icontrol-rest',
-        'genie',
     ],
 
     # any additional groups of dependencies.


### PR DESCRIPTION
Removing genie from rest dependencies, as it is a two-way dependency which can cause issues with development mode