### PR TITLE
Fix nxos put and patch documentation. Fix paths in README.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ To build the docs locally on your machine. Please follow the instructions below
     git clone https://github.com/<your_github_username>/rest.git
     ```
 
-  - ```cd rest/connector/docs```
+  - ```cd rest/docs```
   
   - Use ```make install_build_deps```  to install all of the build dependencies
   
@@ -26,7 +26,7 @@ To build the docs locally on your machine. Please follow the instructions below
   - Wait until you see ```Done``` in your terminal
   
   - The documentation is now built and stored under the directory 
-  ```rest/connector/__build__```
+  ```rest/__build__```
 
   - Run ```make serve``` to view the documentation on your browser or navigate to the repository.
     

--- a/docs/user_guide/services/nxos.rst
+++ b/docs/user_guide/services/nxos.rst
@@ -156,7 +156,7 @@ API to send PATCH command to the device.
       }
     """
     url = '/api/mo/sys/bgp/inst/dom-default/af-ipv4-mvpn.json'
-    output = device.rest.patch(url)
+    output = device.rest.patch(url, payload)
 
 put
 ---
@@ -191,7 +191,7 @@ API to send PUT command to the device.
       }
     """
     url = '/api/mo/sys/bgp/inst/dom-default/af-ipv4-mvpn.json'
-    output = device.rest.put(url)
+    output = device.rest.put(url, payload)
 
 .. sectionauthor:: Jean-Benoit Aubin <jeaubin@cisco.com>
 


### PR DESCRIPTION
Hi everyone,
I believe that in the NXOS documentation the payload is missing in the put and patch requests.