### PR TITLE
fixed nxos request header

### DIFF
--- a/src/rest/connector/libs/nxos/implementation.py
+++ b/src/rest/connector/libs/nxos/implementation.py
@@ -279,10 +279,18 @@ class Implementation(Implementation):
                          furl=full_url,
                          p=p))
 
+        if not isinstance(kwargs.get('headers'), dict):
+            kwargs['headers'] = {
+                'Content-Type': 'application/yang.data+json',
+                'Accept': 'application/yang.data+json'
+            }
+
         # Send to the device
         for _ in range(retries):
             try:
-                response = self.session.request(method=method, url=full_url, **kwargs)
+                response = self.session.request(
+                    method=method, url=full_url, **kwargs
+                )
                 break
             except Exception:
                 log.warning('Request {} to {} failed. Waiting {} seconds before retrying\n'.format(

--- a/src/rest/connector/tests/test_nxos.py
+++ b/src/rest/connector/tests/test_nxos.py
@@ -3,10 +3,10 @@
 import os
 import logging
 import unittest
+
 from requests.models import Response
 from unittest.mock import patch, MagicMock
 from requests.exceptions import RequestException
-
 from pyats.topology import loader
 
 from rest.connector import Rest
@@ -70,10 +70,6 @@ class test_rest_connector(unittest.TestCase):
             connection.disconnect()
         self.assertEqual(connection.connected, False)
 
-    def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(dn='temp', payload={'payload':'something'})
 
     def test_post_connected(self):
         connection = Rest(device=self.device, alias='rest', via='rest')
@@ -361,4 +357,20 @@ class test_rest_connector(unittest.TestCase):
             self.assertEqual(connection.connected, True)
             connection.disconnect()
 
+        self.assertEqual(connection.connected, False)
+
+    def test_headers(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            connection.connect()
+            resp.json = MagicMock(return_value={'imdata': []})
+            connection.post(
+                dn='temp', payload={'payload': 'something'}, headers='str'
+            )
+            connection.disconnect()
         self.assertEqual(connection.connected, False)


### PR DESCRIPTION
NXOS endpoint is expecting a dictionary for the headers instance of the string.  But, the current implementation passes a string.