### PR TITLE
fixed nxos response

### DIFF
--- a/src/rest/connector/libs/nxos/implementation.py
+++ b/src/rest/connector/libs/nxos/implementation.py
@@ -331,15 +331,7 @@ class Implementation(Implementation):
                          c=response.status_code,
                          r=response.text))
 
-        # In case the response cannot be decoded into json
-        # warn and return the raw text
-        try:
-            output = response.json()
-        except Exception:
-            log.warning('Could not decode json. Returning text!')
-            output = response.text
-
-        return output
+        return response
 
     @BaseConnection.locked
     @isconnected

--- a/src/rest/connector/tests/test_nxos.py
+++ b/src/rest/connector/tests/test_nxos.py
@@ -374,3 +374,18 @@ class test_rest_connector(unittest.TestCase):
             )
             connection.disconnect()
         self.assertEqual(connection.connected, False)
+
+    def test_response(self):
+        connection = Rest(device=self.device, alias='rest', via='rest')
+        self.assertEqual(connection.connected, False)
+
+        with patch('requests.Session') as req:
+            resp = Response()
+            resp.status_code = 200
+            req().post.return_value = resp
+            connection.connect()
+            resp.json = MagicMock(return_value={'imdata': []})
+            self.assertEqual(connection.connected, True)
+
+            connection.disconnect()
+        self.assertEqual(connection.connected, False)


### PR DESCRIPTION
All devices implementations return a request response object but nxOS implementation returns a dictionary so It caused an exception on the genielibs. 
