### PR TITLE
Avoid contant disconnect/reconnect in isconnected decorator

### DIFF
--- a/src/rest/connector/libs/apic/implementation.py
+++ b/src/rest/connector/libs/apic/implementation.py
@@ -179,15 +179,16 @@ class Implementation(Imp):
            faster to reconnect every time.
          '''
         def decorated(self, *args, **kwargs):
-            # Check if connected
             try:
+                ret = func(self, *args, **kwargs)
+            except:
                 self.disconnect()
 
                 if 'timeout' in kwargs:
                     self.connect(timeout=kwargs['timeout'])
                 else:
                     self.connect()
-            finally:
+
                 ret = func(self, *args, **kwargs)
             return ret
         return decorated
@@ -280,13 +281,14 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("Sending '{furl} to '{d} has returned the "
+            raise RequestException("GET {furl} to {d} has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{e}'"
-                                   "'{e}'".format(furl=full_url,
+                                   ", got:\n {msg}".format(furl=full_url,
                                                   d=self.device.name,
                                                   c=response.status_code,
-                                                  e=expected_status_code))
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output
 
     @BaseConnection.locked
@@ -344,13 +346,14 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("'{c}' result code has been returned "
-                                   "instead of the expected status code "
-                                   "'{e}' for '{d}', got:\n {msg}"\
-                                   .format(d=self.device.name,
-                                           c=response.status_code,
-                                           e=expected_status_code,
-                                           msg=response.text))
+            raise RequestException("POST {furl} to {d} has returned the "
+                                   "following code '{c}', instead of the "
+                                   "expected status code '{e}'"
+                                   ", got:\n {msg}".format(furl=full_url,
+                                                  d=self.device.name,
+                                                  c=response.status_code,
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output
 
     @BaseConnection.locked
@@ -385,10 +388,12 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("'{c}' result code has been returned "
-                                   "instead of the expected status code "
-                                   "'{e}' for '{d}'"\
-                                   .format(d=self.device.name,
-                                           c=response.status_code,
-                                           e=expected_status_code))
+            raise RequestException("DELETE {furl} to {d} has returned the "
+                                   "following code '{c}', instead of the "
+                                   "expected status code '{e}'"
+                                   ", got:\n {msg}".format(furl=full_url,
+                                                  d=self.device.name,
+                                                  c=response.status_code,
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output

--- a/src/rest/connector/libs/nd/implementation.py
+++ b/src/rest/connector/libs/nd/implementation.py
@@ -168,15 +168,16 @@ class Implementation(Imp):
          """
 
         def decorated(self, *args, **kwargs):
-            # Check if connected
             try:
+                ret = func(self, *args, **kwargs)
+            except:
                 self.disconnect()
 
                 if 'timeout' in kwargs:
                     self.connect(timeout=kwargs['timeout'])
                 else:
                     self.connect()
-            finally:
+
                 ret = func(self, *args, **kwargs)
             return ret
 
@@ -233,13 +234,14 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("Sending '{furl} to '{d} has returned the "
+            raise RequestException("GET {furl} to {d} has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{e}'"
-                                   "'{e}'".format(furl=full_url,
+                                   ", got:\n {msg}".format(furl=full_url,
                                                   d=self.device.name,
                                                   c=response.status_code,
-                                                  e=expected_status_code))
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output
 
     @BaseConnection.locked
@@ -315,13 +317,14 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("'{c}' result code has been returned "
-                                   "instead of the expected status code "
-                                   "'{e}' for '{d}', got:\n {msg}" \
-                                   .format(d=self.device.name,
-                                           c=response.status_code,
-                                           e=expected_status_code,
-                                           msg=response.text))
+            raise RequestException("POST {furl} to {d} has returned the "
+                                   "following code '{c}', instead of the "
+                                   "expected status code '{e}'"
+                                   ", got:\n {msg}".format(furl=full_url,
+                                                  d=self.device.name,
+                                                  c=response.status_code,
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output
 
     @BaseConnection.locked
@@ -397,13 +400,14 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("'{c}' result code has been returned "
-                                   "instead of the expected status code "
-                                   "'{e}' for '{d}', got:\n {msg}" \
-                                   .format(d=self.device.name,
-                                           c=response.status_code,
-                                           e=expected_status_code,
-                                           msg=response.text))
+            raise RequestException("PUT {furl} to {d} has returned the "
+                                   "following code '{c}', instead of the "
+                                   "expected status code '{e}'"
+                                   ", got:\n {msg}".format(furl=full_url,
+                                                  d=self.device.name,
+                                                  c=response.status_code,
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output
 
     @BaseConnection.locked
@@ -435,7 +439,7 @@ class Implementation(Imp):
                 # Send to the device
                 response = self.session.delete(full_url, timeout=timeout, verify=False)
                 break
-            except Exception as e:
+            except Exception:
                 log.warning('Request to {} failed. Waiting {} seconds before retrying\n'.format(
                     self.device.name, retry_wait), exc_info=True)
                 time.sleep(retry_wait)
@@ -456,11 +460,12 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("'{c}' result code has been returned "
-                                   "instead of the expected status code "
-                                   "'{e}' for '{d}'" \
-                                   .format(d=self.device.name,
-                                           c=response.status_code,
-                                           e=expected_status_code))
-
+            raise RequestException("DELETE {furl} to {d} has returned the "
+                                   "following code '{c}', instead of the "
+                                   "expected status code '{e}'"
+                                   ", got:\n {msg}".format(furl=full_url,
+                                                  d=self.device.name,
+                                                  c=response.status_code,
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output

--- a/src/rest/connector/libs/nxos/aci/implementation.py
+++ b/src/rest/connector/libs/nxos/aci/implementation.py
@@ -171,15 +171,16 @@ class Implementation(Imp):
            faster to reconnect every time.
          '''
         def decorated(self, *args, **kwargs):
-            # Check if connected
             try:
+                ret = func(self, *args, **kwargs)
+            except:
                 self.disconnect()
 
                 if 'timeout' in kwargs:
                     self.connect(timeout=kwargs['timeout'])
                 else:
                     self.connect()
-            finally:
+
                 ret = func(self, *args, **kwargs)
             return ret
         return decorated
@@ -260,13 +261,14 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("Sending '{furl} to '{d} has returned the "
+            raise RequestException("GET {furl} to {d} has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{e}'"
-                                   "'{e}'".format(furl=full_url,
+                                   ", got:\n {msg}".format(furl=full_url,
                                                   d=self.device.name,
                                                   c=response.status_code,
-                                                  e=expected_status_code))
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output
 
     @BaseConnection.locked
@@ -307,13 +309,14 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("'{c}' result code has been returned "
-                                   "instead of the expected status code "
-                                   "'{e}' for '{d}', got:\n {msg}"\
-                                   .format(d=self.device.name,
-                                           c=response.status_code,
-                                           e=expected_status_code,
-                                           msg=response.text))
+            raise RequestException("POST {furl} to {d} has returned the "
+                                   "following code '{c}', instead of the "
+                                   "expected status code '{e}'"
+                                   ", got:\n {msg}".format(furl=full_url,
+                                                  d=self.device.name,
+                                                  c=response.status_code,
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output
 
     @BaseConnection.locked
@@ -348,10 +351,12 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != expected_status_code:
             # Something bad happened
-            raise RequestException("'{c}' result code has been returned "
-                                   "instead of the expected status code "
-                                   "'{e}' for '{d}'"\
-                                   .format(d=self.device.name,
-                                           c=response.status_code,
-                                           e=expected_status_code))
+            raise RequestException("DELETE {furl} to {d} has returned the "
+                                   "following code '{c}', instead of the "
+                                   "expected status code '{e}'"
+                                   ", got:\n {msg}".format(furl=full_url,
+                                                  d=self.device.name,
+                                                  c=response.status_code,
+                                                  e=expected_status_code,
+                                                  msg=response.text))
         return output

--- a/src/rest/connector/libs/nxos/implementation.py
+++ b/src/rest/connector/libs/nxos/implementation.py
@@ -218,8 +218,9 @@ class Implementation(Implementation):
            faster to reconnect every time.
          '''
         def decorated(self, *args, **kwargs):
-            # Check if connected
             try:
+                ret = func(self, *args, **kwargs)
+            except:
                 log.propagate = False
                 self.disconnect()
 

--- a/src/rest/connector/tests/test_apic.py
+++ b/src/rest/connector/tests/test_apic.py
@@ -108,7 +108,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp2, resp, resp, resp2]
+            req().post.side_effect = [resp, resp2, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -130,7 +130,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp2, resp, resp, resp2]
+            req().post.side_effect = [resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -152,7 +152,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp2, resp, resp, resp2]
+            req().post.side_effect = [resp, resp2, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})

--- a/src/rest/connector/tests/test_apic.py
+++ b/src/rest/connector/tests/test_apic.py
@@ -108,7 +108,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2, resp2]
+            req().post.side_effect = [resp2, resp, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -130,7 +130,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2, resp2]
+            req().post.side_effect = [resp2, resp, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -152,7 +152,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2, resp2]
+            req().post.side_effect = [resp2, resp, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})

--- a/src/rest/connector/tests/test_nd.py
+++ b/src/rest/connector/tests/test_nd.py
@@ -100,7 +100,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp2, resp, resp, resp2]
+            req().post.side_effect = [resp, resp2, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -122,7 +122,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp2, resp, resp, resp2]
+            req().post.side_effect = [resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -144,7 +144,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp2, resp, resp, resp2]
+            req().post.side_effect = [resp, resp2, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})

--- a/src/rest/connector/tests/test_nd.py
+++ b/src/rest/connector/tests/test_nd.py
@@ -100,7 +100,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2, resp2]
+            req().post.side_effect = [resp2, resp, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -122,7 +122,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2, resp2]
+            req().post.side_effect = [resp2, resp, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})
@@ -144,7 +144,7 @@ class test_rest_connector(unittest.TestCase):
             resp2 = Response()
             resp2.status_code = 300
             req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2, resp2]
+            req().post.side_effect = [resp2, resp, resp, resp2]
 
             connection.connect()
             resp.json = MagicMock(return_value={'imdata': []})


### PR DESCRIPTION
Current decorator does disconnect and re-connect for every request. That significantly slows down the rate of requests and creates problems with some devices/accounts, that have small number of active sessions allowed, as sessions are not getting removed from the account for some time and sessions limit is getting hit. The proposed decorator sends request first, and if request returns the exception (because of token expiry or session disconnect or any other reason), then decorator will do disconnect and re-connect and will repeat the request. That approach sends all requests over one session and provides automatic recovery when session/token expires.
Another part of this change - make consistent exception message in all requests and provide response message/error everywhere, so it is easier to debug those exceptions.