### PR TITLE
Ability to disable query-target/rsp-subtree/rsp-prop-include in GET r…

### DIFF
--- a/src/rest/connector/libs/apic/implementation.py
+++ b/src/rest/connector/libs/apic/implementation.py
@@ -238,13 +238,20 @@ class Implementation(Imp):
                             "alias '{a}'".format(d=self.device.name,
                                                  a=self.alias))
 
-        full_url = "{f}{dn}?query-target={qt}&rsp-subtree={rs}"\
-                        "&rsp-prop-include={rpi}"\
-                          .format(f=self.url,
-                                  dn=dn,
-                                  qt=query_target,
-                                  rs=rsp_subtree,
-                                  rpi=rsp_prop_include)
+        full_url = "{f}{dn}".format(f=self.url, dn=dn.lstrip('/'))
+
+        if query_target:
+            full_url += "?query-target={qt}"\
+                .format(qt=query_target)
+
+        if rsp_subtree:
+            full_url += "&rsp-subtree={rs}"\
+                .format(rs=rsp_subtree)
+
+        if rsp_prop_include:
+            full_url += "&rsp-prop-include={rpi}"\
+                .format(rpi=rsp_prop_include)
+
         if query_target_filter:
             full_url += "&query-target-filter={qtf}"\
                 .format(qtf=query_target_filter)
@@ -313,7 +320,7 @@ class Implementation(Imp):
                             "alias '{a}'".format(d=self.device.name,
                                                  a=self.alias))
         # Deal with the dn
-        full_url = '{f}{dn}'.format(f=self.url, dn=dn)
+        full_url = '{f}{dn}'.format(f=self.url, dn=dn.lstrip('/'))
 
         log.info("Sending POST command to '{d}':"\
                  "\nDN: {furl}\nPayload:{p}".format(d=self.device.name,
@@ -375,7 +382,7 @@ class Implementation(Imp):
                                                  a=self.alias))
 
         # Deal with the dn
-        full_url = '{f}{dn}'.format(f=self.url, dn=dn)
+        full_url = '{f}{dn}'.format(f=self.url, dn=dn.lstrip('/'))
 
         log.info("Sending DELETE command to '{d}':"\
                  "\nDN: {furl}".format(d=self.device.name, furl=full_url))

--- a/src/rest/connector/libs/nxos/aci/implementation.py
+++ b/src/rest/connector/libs/nxos/aci/implementation.py
@@ -226,13 +226,20 @@ class Implementation(Imp):
                             "alias '{a}'".format(d=self.device.name,
                                                  a=self.alias))
 
-        full_url = "{f}{dn}?query-target={qt}&rsp-subtree={rs}"\
-                        "&rsp-prop-include={rpi}"\
-                          .format(f=self.url,
-                                  dn=dn,
-                                  qt=query_target,
-                                  rs=rsp_subtree,
-                                  rpi=rsp_prop_include)
+        full_url = "{f}{dn}".format(f=self.url, dn=dn.lstrip('/'))
+
+        if query_target:
+            full_url += "?query-target={qt}"\
+                .format(qt=query_target)
+
+        if rsp_subtree:
+            full_url += "&rsp-subtree={rs}"\
+                .format(rs=rsp_subtree)
+
+        if rsp_prop_include:
+            full_url += "&rsp-prop-include={rpi}"\
+                .format(rpi=rsp_prop_include)
+
         if query_target_filter:
             full_url += "&query-target-filter={qtf}"\
                 .format(qtf=query_target_filter)
@@ -293,7 +300,7 @@ class Implementation(Imp):
                             "alias '{a}'".format(d=self.device.name,
                                                  a=self.alias))
         # Deal with the dn
-        full_url = '{f}{dn}'.format(f=self.url, dn=dn)
+        full_url = '{f}{dn}'.format(f=self.url, dn=dn.lstrip('/'))
 
         log.info("Sending POST command to '{d}':"\
                  "\nDN: {furl}\nPayload:{p}".format(d=self.device.name,
@@ -338,7 +345,7 @@ class Implementation(Imp):
                                                  a=self.alias))
 
         # Deal with the dn
-        full_url = '{f}{dn}'.format(f=self.url, dn=dn)
+        full_url = '{f}{dn}'.format(f=self.url, dn=dn.lstrip('/'))
 
         log.info("Sending DELETE command to '{d}':"\
                  "\nDN: {furl}".format(d=self.device.name, furl=full_url))


### PR DESCRIPTION
In apic and nxos/aci connectors GET request has query-target/rsp-subtree/rsp-prop-include parameters always added to url.
This does not work for some api requests - for example /mqapi2/deployment.query.json?mode=getvmmCapInfo - that api fails with addition of those parameters.
Changed the code, to give calling function ability to disable those parameters in get, but providing empty values for them, like it is done for other parameters.
Default values for those parameters are non-empty, so it does not change anything for existing scripts.
Also made left stripping "/" in the dn, as that api also fails with "//" in the url - as one "/" is already provided by connect function and another "/" may be present in the dn. This makes apic and nxos connectors consistent with handling dn parameter with and without leading "/".