### PR TITLE
Fix the UT for viptela

### DIFF
--- a/src/rest/connector/tests/test_viptela.py
+++ b/src/rest/connector/tests/test_viptela.py
@@ -79,6 +79,7 @@ class test_rest_connector(unittest.TestCase):
 
         with patch('requests.session') as req:
             resp = Response()
+            resp.raw = MagicMock()
             resp.status_code = 200
             req().post.return_value = resp
             req().get.return_value = resp
@@ -100,6 +101,7 @@ class test_rest_connector(unittest.TestCase):
 
         with patch('requests.session') as req:
             resp = Response()
+            resp.raw = MagicMock()
             resp.status_code = 200
             req().post.return_value = resp
             req().get.return_value = resp
@@ -115,8 +117,10 @@ class test_rest_connector(unittest.TestCase):
 
         with patch('requests.session') as req:
             resp = Response()
+            resp.raw = MagicMock()
             resp.status_code = 200
             resp2 = Response()
+            resp2.raw = MagicMock()
             resp2.status_code = 300
             req().get.side_effect = [resp, resp2]
             req().post.side_effect = [resp, resp, resp2]
@@ -141,6 +145,7 @@ class test_rest_connector(unittest.TestCase):
 
         with patch('requests.session') as req:
             resp = Response()
+            resp.raw = MagicMock()
             resp.status_code = 200
             req().post.return_value = resp
             req().get.return_value = resp
@@ -157,8 +162,10 @@ class test_rest_connector(unittest.TestCase):
 
         with patch('requests.session') as req:
             resp = Response()
+            resp.raw = MagicMock()
             resp.status_code = 200
             resp2 = Response()
+            resp2.raw = MagicMock()
             resp2.status_code = 300
             req().delete.return_value = resp2
             req().post.side_effect = [resp, resp, resp2]


### PR DESCRIPTION
Fix the mock for the raw response

```
======================================================================
ERROR: test_delete_connected (test_viptela.test_rest_connector.test_delete_connected)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "xxx/rest/src/rest/connector/tests/test_viptela.py", line 150, in test_delete_connected
    connection.delete(mount_point='temp')
  File "xxx/pyats/pkgs/async-pkg/src/pyats/async_/synchronize.py", line 117, in _wrapped
    return method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/rest/src/rest/connector/libs/viptela/implementation.py", line 335, in delete
    log.info("Output received:\n{response}".format(response=response))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/yang/ncdiff/src/yang/ncdiff/__init__.py", line 69, in _str_response
    if self.raw.version in http_versions:
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'version'

======================================================================
ERROR: test_delete_connected_change_expected (test_viptela.test_rest_connector.test_delete_connected_change_expected)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "xxx/rest/src/rest/connector/tests/test_viptela.py", line 169, in test_delete_connected_change_expected
    connection.delete(mount_point='temp')
  File "xxx/pyats/pkgs/async-pkg/src/pyats/async_/synchronize.py", line 117, in _wrapped
    return method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/rest/src/rest/connector/libs/viptela/implementation.py", line 335, in delete
    log.info("Output received:\n{response}".format(response=response))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/yang/ncdiff/src/yang/ncdiff/__init__.py", line 69, in _str_response
    if self.raw.version in http_versions:
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'version'

======================================================================
ERROR: test_get_connected (test_viptela.test_rest_connector.test_get_connected)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "xxx/rest/src/rest/connector/tests/test_viptela.py", line 108, in test_get_connected
    connection.get(mount_point='temp')
  File "xxx/pyats/pkgs/async-pkg/src/pyats/async_/synchronize.py", line 117, in _wrapped
    return method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/rest/src/rest/connector/libs/viptela/implementation.py", line 210, in get
    log.info("Output received:\n{response}".format(response=response))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/yang/ncdiff/src/yang/ncdiff/__init__.py", line 69, in _str_response
    if self.raw.version in http_versions:
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'version'

======================================================================
ERROR: test_get_connected_change_expected (test_viptela.test_rest_connector.test_get_connected_change_expected)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "xxx/rest/src/rest/connector/tests/test_viptela.py", line 128, in test_get_connected_change_expected
    connection.get(mount_point='temp')
  File "xxx/pyats/pkgs/async-pkg/src/pyats/async_/synchronize.py", line 117, in _wrapped
    return method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/rest/src/rest/connector/libs/viptela/implementation.py", line 210, in get
    log.info("Output received:\n{response}".format(response=response))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/yang/ncdiff/src/yang/ncdiff/__init__.py", line 69, in _str_response
    if self.raw.version in http_versions:
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'version'

======================================================================
ERROR: test_post_connected (test_viptela.test_rest_connector.test_post_connected)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "xxx/rest/src/rest/connector/tests/test_viptela.py", line 87, in test_post_connected
    connection.post(mount_point='temp',
  File "xxx/pyats/pkgs/async-pkg/src/pyats/async_/synchronize.py", line 117, in _wrapped
    return method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/rest/src/rest/connector/libs/viptela/implementation.py", line 253, in post
    log.info("Output received:\n{response}".format(response=response))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/yang/ncdiff/src/yang/ncdiff/__init__.py", line 69, in _str_response
    if self.raw.version in http_versions:
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'version'

----------------------------------------------------------------------
```
