### PR TITLE
Closes #138 IOS-XE certificate validation

### DIFF
--- a/src/rest/connector/libs/iosxe/implementation.py
+++ b/src/rest/connector/libs/iosxe/implementation.py
@@ -96,6 +96,7 @@ class Implementation(RestImplementation):
         log.debug("Timeout: %s" % timeout)
         self.content_type = default_content_type
 
+        self.verify = self.connection_info.get('verify', True)
         # support sshtunnel
         if 'sshtunnel' in self.connection_info:
             try:
@@ -136,6 +137,7 @@ class Implementation(RestImplementation):
 
         self.session = requests.Session()
         self.session.auth = (username, password)
+        self.session.verify = self.verify
 
         header = 'application/yang-data+{fmt}'
 
@@ -150,7 +152,7 @@ class Implementation(RestImplementation):
 
         # Connect to the device via requests
         response = self.session.get(
-            login_url, proxies=self.proxies, timeout=timeout, verify=False)
+            login_url, proxies=self.proxies, timeout=timeout)
         output = response.text
         log.debug("Response: {c} {r}, headers: {h}, payload {p}".format(
             c=response.status_code,


### PR DESCRIPTION
Added the option to control certificate validation, to the device connection as:

```yaml
devices:
  eWLC:
        os: iosxe
        type: eWLC
        custom:
          abstraction:
            order: [os]
        connections:
          rest:
            class: rest.connector.Rest
            ip: 198.51.100.3
            #verify: True                  # <-- Enable certificate validation (default)
            verify: False                  # <-- Disable certificate validation (default)            
````

This setting is applied to the `requests.session` object once, which is applied to all following operations like GET, POST etc.