### PR TITLE
Updated IOS XE implementation to support hostname instead of IP

### DIFF
--- a/src/rest/connector/libs/apic/acisdk_implementation.py
+++ b/src/rest/connector/libs/apic/acisdk_implementation.py
@@ -1,6 +1,7 @@
 import requests
 import urllib3
 
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from functools import wraps
 from importlib import import_module
 from logging import getLogger
@@ -57,7 +58,16 @@ class AciCobra(BaseConnection):
         if 'host' in self.connection_info:
             ip = self.connection_info['host']
         else:
-            ip = self.connection_info['ip'].exploded
+            ip = self.connection_info['ip']
+            if not isinstance(ip, (IPv4Address, IPv6Address)):
+                ip = ip_address(ip)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(ip, IPv6Address):
+                ip = f"[{ip.exploded}]"
+            else:
+                ip = ip.exploded
+
         if 'port' in self.connection_info:
             port = self.connection_info['port']
             self.url = f'https://{ip}:{port}/'

--- a/src/rest/connector/libs/apic/acisdk_implementation.py
+++ b/src/rest/connector/libs/apic/acisdk_implementation.py
@@ -55,26 +55,26 @@ class AciCobra(BaseConnection):
 
         self._is_connected = False
 
-        if 'host' in self.connection_info:
-            ip = self.connection_info['host']
-        else:
-            ip = self.connection_info['ip']
-            if not isinstance(ip, (IPv4Address, IPv6Address)):
-                ip = ip_address(ip)
+        try:
+            host = self.connection_info['host']
+        except KeyError:
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
 
             # Properly format IPv6 URL if a v6 address is provided
-            if isinstance(ip, IPv6Address):
-                ip = f"[{ip.exploded}]"
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
             else:
-                ip = ip.exploded
+                host = host.exploded
 
         if 'port' in self.connection_info:
             port = self.connection_info['port']
-            self.url = f'https://{ip}:{port}/'
+            self.url = f'https://{host}:{port}/'
         else:
-            self.url = f'https://{ip}/'
+            self.url = f'https://{host}/'
 
-        verify_apic_version(ip)
+        verify_apic_version(host)
 
     @property
     def connected(self):

--- a/src/rest/connector/libs/apic/implementation.py
+++ b/src/rest/connector/libs/apic/implementation.py
@@ -3,6 +3,7 @@ import json
 import logging
 import requests
 
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from requests.exceptions import RequestException
 
 
@@ -102,7 +103,16 @@ class Implementation(Imp):
         if 'host' in self.connection_info:
             ip = self.connection_info['host']
         else:
-            ip = self.connection_info['ip'].exploded
+            ip = self.connection_info['ip']
+            if not isinstance(ip, (IPv4Address, IPv6Address)):
+                ip = ip_address(ip)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(ip, IPv6Address):
+                ip = f"[{ip.exploded}]"
+            else:
+                ip = ip.exploded
+
         if 'port' in self.connection_info:
             port = self.connection_info['port']
             self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)

--- a/src/rest/connector/libs/apic/implementation.py
+++ b/src/rest/connector/libs/apic/implementation.py
@@ -100,24 +100,25 @@ class Implementation(Imp):
         if self.connected:
             return
 
-        if 'host' in self.connection_info:
-            ip = self.connection_info['host']
-        else:
-            ip = self.connection_info['ip']
-            if not isinstance(ip, (IPv4Address, IPv6Address)):
-                ip = ip_address(ip)
+        try:
+            host = self.connection_info['host']
+        except KeyError:
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
 
             # Properly format IPv6 URL if a v6 address is provided
-            if isinstance(ip, IPv6Address):
-                ip = f"[{ip.exploded}]"
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
             else:
-                ip = ip.exploded
+                host = host.exploded
+
 
         if 'port' in self.connection_info:
             port = self.connection_info['port']
-            self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)
+            self.url = 'https://{host}:{port}/'.format(host=host, port=port)
         else:
-            self.url = 'https://{ip}/'.format(ip=ip)
+            self.url = 'https://{host}/'.format(host=host)
         login_url = '{f}api/aaaLogin.json'.format(f=self.url)
 
         username, password = get_username_password(self)

--- a/src/rest/connector/libs/apic/implementation.py
+++ b/src/rest/connector/libs/apic/implementation.py
@@ -152,10 +152,10 @@ class Implementation(Imp):
                 if response.status_code != requests.codes.ok:
                     log.error(response.text)
                     # Something bad happened
-                    raise RequestException("Connection to '{ip}' has returned the "
+                    raise RequestException("Connection to '{host}' has returned the "
                                            "following code '{c}', instead of the "
                                            "expected status code '{ok}'"
-                                           .format(ip=ip, c=response.status_code,
+                                           .format(host=host, c=response.status_code,
                                                    ok=requests.codes.ok))
                 break
             except Exception:

--- a/src/rest/connector/libs/bigip/implementation.py
+++ b/src/rest/connector/libs/bigip/implementation.py
@@ -2,6 +2,8 @@
 import logging
 import time
 
+from ipaddress import ip_address, IPv4Address, IPv6Address
+
 # Genie, pyATS, ROBOT imports
 # from pyats.connections import BaseConnection
 from rest.connector.utils import get_username_password
@@ -169,15 +171,28 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            self.ip = self.connection_info['ip'].exploded
-            self.port = self.connection_info.get('port', port)
+            if 'host' in self.connection_info:
+                ip = self.connection_info['host']
+            else:
+                ip = self.connection_info['ip']
+                if not isinstance(ip, (IPv4Address, IPv6Address)):
+                    ip = ip_address(ip)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(ip, IPv6Address):
+                    ip = f"[{ip.exploded}]"
+                else:
+                    ip = ip.exploded
+
+            # self.ip = self.connection_info['ip'].exploded
+            # self.port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
 
         self.base_url = '{protocol}://{ip}:{port}'.format(protocol=protocol,
-                                                          ip=self.ip,
-                                                          port=self.port)
+                                                          ip=ip,
+                                                          port=port)
 
         self.username, self.password = get_username_password(self)
 

--- a/src/rest/connector/libs/bigip/implementation.py
+++ b/src/rest/connector/libs/bigip/implementation.py
@@ -171,28 +171,25 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            if 'host' in self.connection_info:
-                ip = self.connection_info['host']
-            else:
-                ip = self.connection_info['ip']
-                if not isinstance(ip, (IPv4Address, IPv6Address)):
-                    ip = ip_address(ip)
+            try:
+                host = self.connection_info['host']
+            except KeyError:
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
 
                 # Properly format IPv6 URL if a v6 address is provided
-                if isinstance(ip, IPv6Address):
-                    ip = f"[{ip.exploded}]"
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
                 else:
-                    ip = ip.exploded
-
-            # self.ip = self.connection_info['ip'].exploded
-            # self.port = self.connection_info.get('port', port)
+                    host = host.exploded
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
 
-        self.base_url = '{protocol}://{ip}:{port}'.format(protocol=protocol,
-                                                          ip=ip,
-                                                          port=port)
+        self.base_url = '{protocol}://{host}:{port}'.format(protocol=protocol,
+                                                            host=host,
+                                                            port=port)
 
         self.username, self.password = get_username_password(self)
 

--- a/src/rest/connector/libs/dcnm/implementation.py
+++ b/src/rest/connector/libs/dcnm/implementation.py
@@ -2,6 +2,7 @@ __author__ = "Sukanya Kalluri <sukkallu@cisco.com>"
 
 import json
 import logging
+from ipaddress import ip_address, IPv4Address, IPv6Address
 import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
@@ -128,7 +129,16 @@ class Implementation(Implementation):
             try:
                 host = self.connection_info['host']
             except KeyError:
-                host = self.connection_info['ip'].exploded
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
+                else:
+                    host = host.exploded
+
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:

--- a/src/rest/connector/libs/dnac/implementation.py
+++ b/src/rest/connector/libs/dnac/implementation.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import requests
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 
@@ -78,7 +79,15 @@ class Implementation(Implementation):
         try:
             host = self.connection_info['host']
         except KeyError:
-            host = self.connection_info['ip'].exploded
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
+            else:
+                host = host.exploded
         
         port = self.connection_info.get('port', 443)
         self.verify = self.connection_info.get('verify', True)

--- a/src/rest/connector/libs/elasticsearch/implementation.py
+++ b/src/rest/connector/libs/elasticsearch/implementation.py
@@ -2,6 +2,7 @@ import json
 import logging
 import requests
 
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from requests.exceptions import RequestException
 
 from pyats.connections import BaseConnection
@@ -94,7 +95,16 @@ class Implementation(Imp):
         if 'host' in self.connection_info:
             ip = self.connection_info['host']
         else:
-            ip = self.connection_info['ip'].exploded
+            ip = self.connection_info['ip']
+            if not isinstance(ip, (IPv4Address, IPv6Address)):
+                ip = ip_address(ip)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(ip, IPv6Address):
+                ip = f"[{ip.exploded}]"
+            else:
+                ip = ip.exploded
+
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
         if 'port' in self.connection_info:

--- a/src/rest/connector/libs/elasticsearch/implementation.py
+++ b/src/rest/connector/libs/elasticsearch/implementation.py
@@ -92,26 +92,27 @@ class Implementation(Imp):
         if self.connected:
             return
 
-        if 'host' in self.connection_info:
-            ip = self.connection_info['host']
-        else:
-            ip = self.connection_info['ip']
-            if not isinstance(ip, (IPv4Address, IPv6Address)):
-                ip = ip_address(ip)
+        try:
+            host = self.connection_info['host']
+        except KeyError:
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
 
             # Properly format IPv6 URL if a v6 address is provided
-            if isinstance(ip, IPv6Address):
-                ip = f"[{ip.exploded}]"
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
             else:
-                ip = ip.exploded
+                host = host.exploded
+
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
         if 'port' in self.connection_info:
             port = self.connection_info['port']
-            self.url = '{protocol}://{ip}:{port}/'.format(protocol=protocol,
-                                                          ip=ip,
-                                                          port=port)
+            self.url = '{protocol}://{host}:{port}/'.format(protocol=protocol,
+                                                            host=host,
+                                                            port=port)
 
         self.headers = {
             'Content-Type': 'application/json',
@@ -130,10 +131,10 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != requests.codes.ok:
             # Something bad happened
-            raise RequestException("Connection to '{ip}' has returned the "
+            raise RequestException("Connection to '{host}' has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{ok}'"\
-                                        .format(ip=ip, c=response.status_code,
+                                        .format(host=host, c=response.status_code,
                                                 ok=requests.codes.ok))
         self._is_connected = True
         log.info("Connected successfully to '{d}'".format(d=self.device.name))

--- a/src/rest/connector/libs/iosxe/implementation.py
+++ b/src/rest/connector/libs/iosxe/implementation.py
@@ -114,8 +114,11 @@ class Implementation(RestImplementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            ip = self.connection_info.ip.exploded
-            port = self.connection_info.get('port', port)
+            if 'host' in self.connection_info:
+                ip = self.connection_info['host']
+            else:
+                ip = self.connection_info.ip.exploded
+                port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']

--- a/src/rest/connector/libs/iosxe/implementation.py
+++ b/src/rest/connector/libs/iosxe/implementation.py
@@ -3,6 +3,7 @@ import logging
 import re
 import urllib.request
 import requests
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from dict2xml import dict2xml
 from requests.exceptions import RequestException
 
@@ -117,7 +118,16 @@ class Implementation(RestImplementation):
             if 'host' in self.connection_info:
                 ip = self.connection_info['host']
             else:
-                ip = self.connection_info.ip.exploded
+                ip = self.connection_info['ip']
+                if not isinstance(ip, (IPv4Address, IPv6Address)):
+                    ip = ip_address(ip)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(ip, IPv6Address):
+                    ip = f"[{ip.exploded}]"
+                else:
+                    ip = ip.exploded
+
                 port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:

--- a/src/rest/connector/libs/ise/implementation.py
+++ b/src/rest/connector/libs/ise/implementation.py
@@ -1,6 +1,7 @@
 
 import logging
 import urllib.request
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from requests.exceptions import RequestException
 
 from pyats.connections import BaseConnection
@@ -97,7 +98,19 @@ class Implementation(RestImplementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            ip = self.connection_info.ip.exploded
+            if 'host' in self.connection_info:
+                ip = self.connection_info['host']
+            else:
+                ip = self.connection_info['ip']
+                if not isinstance(ip, (IPv4Address, IPv6Address)):
+                    ip = ip_address(ip)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(ip, IPv6Address):
+                    ip = f"[{ip.exploded}]"
+                else:
+                    ip = ip.exploded
+
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:

--- a/src/rest/connector/libs/ise/implementation.py
+++ b/src/rest/connector/libs/ise/implementation.py
@@ -98,27 +98,27 @@ class Implementation(RestImplementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            if 'host' in self.connection_info:
-                ip = self.connection_info['host']
-            else:
-                ip = self.connection_info['ip']
-                if not isinstance(ip, (IPv4Address, IPv6Address)):
-                    ip = ip_address(ip)
+            try:
+                host = self.connection_info['host']
+            except KeyError:
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
 
                 # Properly format IPv6 URL if a v6 address is provided
-                if isinstance(ip, IPv6Address):
-                    ip = f"[{ip.exploded}]"
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
                 else:
-                    ip = ip.exploded
+                    host = host.exploded
 
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
 
-        self.base_url = '{protocol}://{ip}:{port}'.format(protocol=protocol,
-                                                          ip=ip,
-                                                          port=port)
+        self.base_url = '{protocol}://{host}:{port}'.format(protocol=protocol,
+                                                            host=host,
+                                                            port=port)
 
         username, password = get_username_password(self)
 

--- a/src/rest/connector/libs/nd/implementation.py
+++ b/src/rest/connector/libs/nd/implementation.py
@@ -4,6 +4,7 @@ import requests
 import time
 import urllib.parse
 
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from requests.exceptions import RequestException
 
 from pyats.connections import BaseConnection
@@ -94,6 +95,16 @@ class Implementation(Imp):
             ip = self.connection_info['host']
         else:
             ip = self.connection_info['ip'].exploded
+            ip = self.connection_info['ip']
+            if not isinstance(ip, (IPv4Address, IPv6Address)):
+                ip = ip_address(ip)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(ip, IPv6Address):
+                ip = f"[{ip.exploded}]"
+            else:
+                ip = ip.exploded
+
         if 'port' in self.connection_info:
             port = self.connection_info['port']
             self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)

--- a/src/rest/connector/libs/nd/implementation.py
+++ b/src/rest/connector/libs/nd/implementation.py
@@ -140,10 +140,10 @@ class Implementation(Imp):
                 # Make sure it returned requests.codes.ok
                 if response.status_code != requests.codes.ok:
                     # Something bad happened
-                    raise RequestException("Connection to '{ip}' has returned the "
+                    raise RequestException("Connection to '{host}' has returned the "
                                            "following code '{c}', instead of the "
                                            "expected status code '{ok}'"
-                                           .format(ip=ip, c=response.status_code,
+                                           .format(host=host, c=response.status_code,
                                                    ok=requests.codes.ok))
                 break
             except Exception:

--- a/src/rest/connector/libs/nd/implementation.py
+++ b/src/rest/connector/libs/nd/implementation.py
@@ -91,25 +91,25 @@ class Implementation(Imp):
         if self.connected:
             return
 
-        if 'host' in self.connection_info:
-            ip = self.connection_info['host']
-        else:
-            ip = self.connection_info['ip'].exploded
-            ip = self.connection_info['ip']
-            if not isinstance(ip, (IPv4Address, IPv6Address)):
-                ip = ip_address(ip)
+        try:
+            host = self.connection_info['host']
+        except KeyError:
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
 
             # Properly format IPv6 URL if a v6 address is provided
-            if isinstance(ip, IPv6Address):
-                ip = f"[{ip.exploded}]"
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
             else:
-                ip = ip.exploded
+                host = host.exploded
+
 
         if 'port' in self.connection_info:
             port = self.connection_info['port']
-            self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)
+            self.url = 'https://{host}:{port}/'.format(host=host, port=port)
         else:
-            self.url = 'https://{ip}/'.format(ip=ip)
+            self.url = 'https://{host}/'.format(host=host)
         login_url = '{f}login'.format(f=self.url)
 
         username, password = get_username_password(self)

--- a/src/rest/connector/libs/nexusdashboard/implementation.py
+++ b/src/rest/connector/libs/nexusdashboard/implementation.py
@@ -124,7 +124,7 @@ class Implementation(Implementation):
             protocol = self.connection_info['protocol']
 
         self.url = '{protocol}://{host}'.format(protocol=protocol,
-                                                          host=host)
+                                                host=host)
 
         self.verify = self.connection_info.get('verify', True)
 

--- a/src/rest/connector/libs/nexusdashboard/implementation.py
+++ b/src/rest/connector/libs/nexusdashboard/implementation.py
@@ -3,6 +3,8 @@ __author__ = "Daisy Thangapandi <dthangap@cisco.com>"
 import json
 import logging
 import requests
+
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 
@@ -108,7 +110,15 @@ class Implementation(Implementation):
         try:
             host = self.connection_info['host']
         except KeyError:
-            host = self.connection_info['ip'].exploded
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
+            else:
+                host = host.exploded
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']

--- a/src/rest/connector/libs/nso/implementation.py
+++ b/src/rest/connector/libs/nso/implementation.py
@@ -1,6 +1,7 @@
 import re
 import json
 import logging
+from ipaddress import ip_address, IPv4Address, IPv6Address
 import requests
 from dict2xml import dict2xml
 from requests.exceptions import RequestException
@@ -108,7 +109,19 @@ class Implementation(RestImplementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            ip = self.connection_info['ip'].exploded
+            if 'host' in self.connection_info:
+                ip = self.connection_info['host']
+            else:
+                ip = self.connection_info['ip']
+                if not isinstance(ip, (IPv4Address, IPv6Address)):
+                    ip = ip_address(ip)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(ip, IPv6Address):
+                    ip = f"[{ip.exploded}]"
+                else:
+                    ip = ip.exploded
+
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:

--- a/src/rest/connector/libs/nso/implementation.py
+++ b/src/rest/connector/libs/nso/implementation.py
@@ -152,10 +152,10 @@ class Implementation(RestImplementation):
         # Make sure it returned requests.codes.ok
         if response.status_code != requests.codes.ok:
             # Something bad happened
-            raise RequestException("Connection to '{ip}:{port}' has returned the "
+            raise RequestException("Connection to '{host}:{port}' has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{ok}'"\
-                                        .format(ip=ip, port=port, c=response.status_code,
+                                        .format(host=host, port=port, c=response.status_code,
                                                 ok=requests.codes.ok))
         self._is_connected = True
         log.info("Connected successfully to '{d}'".format(d=self.device.name))

--- a/src/rest/connector/libs/nso/implementation.py
+++ b/src/rest/connector/libs/nso/implementation.py
@@ -109,27 +109,27 @@ class Implementation(RestImplementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            if 'host' in self.connection_info:
-                ip = self.connection_info['host']
-            else:
-                ip = self.connection_info['ip']
-                if not isinstance(ip, (IPv4Address, IPv6Address)):
-                    ip = ip_address(ip)
+            try:
+                host = self.connection_info['host']
+            except KeyError:
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
 
                 # Properly format IPv6 URL if a v6 address is provided
-                if isinstance(ip, IPv6Address):
-                    ip = f"[{ip.exploded}]"
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
                 else:
-                    ip = ip.exploded
+                    host = host.exploded
 
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
 
-        self.base_url = '{protocol}://{ip}:{port}'.format(protocol=protocol,
-                                                          ip=ip,
-                                                          port=port)
+        self.base_url = '{protocol}://{host}:{port}'.format(protocol=protocol,
+                                                            host=host,
+                                                            port=port)
 
         self.login_url = '{f}/api'.format(f=self.base_url)
 

--- a/src/rest/connector/libs/nxos/aci/implementation.py
+++ b/src/rest/connector/libs/nxos/aci/implementation.py
@@ -103,24 +103,25 @@ class Implementation(Imp):
         if self.connected:
             return
 
-        if 'host' in self.connection_info:
-            ip = self.connection_info['host']
-        else:
-            ip = self.connection_info['ip']
-            if not isinstance(ip, (IPv4Address, IPv6Address)):
-                ip = ip_address(ip)
+        try:
+            host = self.connection_info['host']
+        except KeyError:
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
 
             # Properly format IPv6 URL if a v6 address is provided
-            if isinstance(ip, IPv6Address):
-                ip = f"[{ip.exploded}]"
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
             else:
-                ip = ip.exploded
+                host = host.exploded
+
 
         if 'port' in self.connection_info:
             port = self.connection_info['port']
-            self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)
+            self.url = 'https://{host}:{port}/'.format(host=host, port=port)
         else:
-            self.url = 'https://{ip}/'.format(ip=ip)
+            self.url = 'https://{host}/'.format(host=host)
         login_url = '{f}api/aaaLogin.json'.format(f=self.url)
 
         username, password = get_username_password(self)

--- a/src/rest/connector/libs/nxos/aci/implementation.py
+++ b/src/rest/connector/libs/nxos/aci/implementation.py
@@ -1,7 +1,8 @@
 import json
 import logging
-import requests
 
+from ipaddress import ip_address, IPv4Address, IPv6Address
+import requests
 from requests.exceptions import RequestException
 
 
@@ -105,7 +106,16 @@ class Implementation(Imp):
         if 'host' in self.connection_info:
             ip = self.connection_info['host']
         else:
-            ip = self.connection_info['ip'].exploded
+            ip = self.connection_info['ip']
+            if not isinstance(ip, (IPv4Address, IPv6Address)):
+                ip = ip_address(ip)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(ip, IPv6Address):
+                ip = f"[{ip.exploded}]"
+            else:
+                ip = ip.exploded
+
         if 'port' in self.connection_info:
             port = self.connection_info['port']
             self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)

--- a/src/rest/connector/libs/nxos/aci/implementation.py
+++ b/src/rest/connector/libs/nxos/aci/implementation.py
@@ -152,10 +152,10 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != requests.codes.ok:
             # Something bad happened
-            raise RequestException("Connection to '{ip}' has returned the "
+            raise RequestException("Connection to '{host}' has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{ok}'"\
-                                        .format(ip=ip, c=response.status_code,
+                                        .format(host=host, c=response.status_code,
                                                 ok=requests.codes.ok))
         self._is_connected = True
         log.info("Connected successfully to '{d}'".format(d=self.device.name))

--- a/src/rest/connector/libs/nxos/implementation.py
+++ b/src/rest/connector/libs/nxos/implementation.py
@@ -137,26 +137,26 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            if 'host' in self.connection_info:
-                ip = self.connection_info['host']
-            else:
-                ip = self.connection_info['ip']
-                if not isinstance(ip, (IPv4Address, IPv6Address)):
-                    ip = ip_address(ip)
+            try:
+                host = self.connection_info['host']
+            except KeyError:
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
 
                 # Properly format IPv6 URL if a v6 address is provided
-                if isinstance(ip, IPv6Address):
-                    ip = f"[{ip.exploded}]"
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
                 else:
-                    ip = ip.exploded
+                    host = host.exploded
 
             port = self.connection_info.get('port', port)
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
 
-        self.url = '{protocol}://{ip}:{port}'.format(protocol=protocol,
-                                                     ip=ip,
-                                                     port=port)
+        self.url = '{protocol}://{host}:{port}'.format(protocol=protocol,
+                                                       host=host,
+                                                       port=port)
 
         login_url = '{f}/api/aaaLogin.json'.format(f=self.url)
 
@@ -198,10 +198,10 @@ class Implementation(Implementation):
         # Make sure it returned requests.codes.ok
         if response.status_code != requests.codes.ok:
             # Something bad happened
-            raise RequestException("Connection to '{ip}' has returned the "
+            raise RequestException("Connection to '{host}' has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{ok}'"
-                                   .format(ip=ip, c=response.status_code,
+                                   .format(host=host, c=response.status_code,
                                            ok=requests.codes.ok))
 
         # Attach auth to session for future calls

--- a/src/rest/connector/libs/nxos/implementation.py
+++ b/src/rest/connector/libs/nxos/implementation.py
@@ -1,6 +1,7 @@
 import json
 import time
 import logging
+from ipaddress import ip_address, IPv4Address, IPv6Address
 import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
@@ -136,7 +137,19 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            ip = self.connection_info['ip'].exploded
+            if 'host' in self.connection_info:
+                ip = self.connection_info['host']
+            else:
+                ip = self.connection_info['ip']
+                if not isinstance(ip, (IPv4Address, IPv6Address)):
+                    ip = ip_address(ip)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(ip, IPv6Address):
+                    ip = f"[{ip.exploded}]"
+                else:
+                    ip = ip.exploded
+
             port = self.connection_info.get('port', port)
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']

--- a/src/rest/connector/libs/viptela/implementation.py
+++ b/src/rest/connector/libs/viptela/implementation.py
@@ -1,7 +1,8 @@
 import json
 import logging
-import requests
+from ipaddress import ip_address, IPv4Address, IPv6Address
 
+import requests
 from pyats.connections import BaseConnection
 from rest.connector.implementation import Implementation
 from rest.connector.utils import get_username_password
@@ -101,7 +102,19 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            ip = self.connection_info['ip'].exploded
+            if 'host' in self.connection_info:
+                ip = self.connection_info['host']
+            else:
+                ip = self.connection_info['ip']
+                if not isinstance(ip, (IPv4Address, IPv6Address)):
+                    ip = ip_address(ip)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(ip, IPv6Address):
+                    ip = f"[{ip.exploded}]"
+                else:
+                    ip = ip.exploded
+
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:

--- a/src/rest/connector/libs/viptela/implementation.py
+++ b/src/rest/connector/libs/viptela/implementation.py
@@ -102,27 +102,27 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            if 'host' in self.connection_info:
-                ip = self.connection_info['host']
-            else:
-                ip = self.connection_info['ip']
-                if not isinstance(ip, (IPv4Address, IPv6Address)):
-                    ip = ip_address(ip)
+            try:
+                host = self.connection_info['host']
+            except KeyError:
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
 
                 # Properly format IPv6 URL if a v6 address is provided
-                if isinstance(ip, IPv6Address):
-                    ip = f"[{ip.exploded}]"
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
                 else:
-                    ip = ip.exploded
+                    host = host.exploded
 
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
 
-        self.base_url = '{protocol}://{ip}:{port}'.format(protocol=protocol,
-                                                          ip=ip,
-                                                          port=port)
+        self.base_url = '{protocol}://{host}:{port}'.format(protocol=protocol,
+                                                            host=host,
+                                                            port=port)
 
         self.verify = self.connection_info.get('verify', False)
 

--- a/src/rest/connector/libs/virl/implementation.py
+++ b/src/rest/connector/libs/virl/implementation.py
@@ -117,27 +117,27 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            if 'host' in self.connection_info:
-                ip = self.connection_info['host']
-            else:
-                ip = self.connection_info['ip']
-                if not isinstance(ip, (IPv4Address, IPv6Address)):
-                    ip = ip_address(ip)
+            try:
+                host = self.connection_info['host']
+            except KeyError:
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
 
                 # Properly format IPv6 URL if a v6 address is provided
-                if isinstance(ip, IPv6Address):
-                    ip = f"[{ip.exploded}]"
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
                 else:
-                    ip = ip.exploded
+                    host = host.exploded
 
             port = self.connection_info.get('port', '19399')
 
         if 'protocol' in self.connection_info:
             protocol = self.connection_info['protocol']
 
-        self.url = '{protocol}://{ip}:{port}'.format(protocol=protocol,
-                                                          ip=ip,
-                                                          port=port)
+        self.url = '{protocol}://{host}:{port}'.format(protocol=protocol,
+                                                       host=host,
+                                                       port=port)
 
         self.username, self.password = get_username_password(self)
         self.headers = {"Content-Type": "text/xml;charset=UTF-8"}

--- a/src/rest/connector/libs/virl/implementation.py
+++ b/src/rest/connector/libs/virl/implementation.py
@@ -164,10 +164,10 @@ class Implementation(Implementation):
         # Make sure it returned requests.codes.ok
         if response.status_code != requests.codes.ok:
             # Something bad happened
-            raise RequestException("Connection to '{ip}' has returned the "
+            raise RequestException("Connection to '{host}' has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{ok}'"\
-                                        .format(ip=ip, c=response.status_code,
+                                        .format(host=host, c=response.status_code,
                                                 ok=requests.codes.ok))
         self._is_connected = True
         log.info("Connected successfully to '{d}'".format(d=self.device.name))

--- a/src/rest/connector/libs/virl/implementation.py
+++ b/src/rest/connector/libs/virl/implementation.py
@@ -1,8 +1,8 @@
 import logging
+from ipaddress import ip_address, IPv4Address, IPv6Address
+
 import requests
-
 from requests.exceptions import RequestException
-
 
 from pyats.connections import BaseConnection
 from rest.connector.implementation import Implementation
@@ -117,7 +117,19 @@ class Implementation(Implementation):
                     "Cannot add ssh tunnel. Connection %s may not have ip/host or port.\n%s"
                     % (self.via, e))
         else:
-            ip = self.connection_info['ip'].exploded
+            if 'host' in self.connection_info:
+                ip = self.connection_info['host']
+            else:
+                ip = self.connection_info['ip']
+                if not isinstance(ip, (IPv4Address, IPv6Address)):
+                    ip = ip_address(ip)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(ip, IPv6Address):
+                    ip = f"[{ip.exploded}]"
+                else:
+                    ip = ip.exploded
+
             port = self.connection_info.get('port', '19399')
 
         if 'protocol' in self.connection_info:

--- a/src/rest/connector/libs/vmware/implementation.py
+++ b/src/rest/connector/libs/vmware/implementation.py
@@ -2,6 +2,8 @@ __author__ = "Sukanya Kalluri <sukkallu@cisco.com>"
 
 import json
 import logging
+from ipaddress import ip_address, IPv4Address, IPv6Address
+
 import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
@@ -128,7 +130,16 @@ class Implementation(Implementation):
             try:
                 host = self.connection_info['host']
             except KeyError:
-                host = self.connection_info['ip'].exploded
+                host = self.connection_info['ip']
+                if not isinstance(host, (IPv4Address, IPv6Address)):
+                    host = ip_address(host)
+
+                # Properly format IPv6 URL if a v6 address is provided
+                if isinstance(host, IPv6Address):
+                    host = f"[{host.exploded}]"
+                else:
+                    host = host.exploded
+
             port = self.connection_info.get('port', port)
 
         if 'protocol' in self.connection_info:

--- a/src/rest/connector/libs/webex/implementation.py
+++ b/src/rest/connector/libs/webex/implementation.py
@@ -94,25 +94,25 @@ class Implementation(Imp):
         if self.connected:
             return
 
-        if 'host' in self.connection_info:
-            ip = self.connection_info['host']
-        else:
-            ip = self.connection_info['ip'].exploded
-            ip = self.connection_info['ip']
-            if not isinstance(ip, (IPv4Address, IPv6Address)):
-                ip = ip_address(ip)
+        try:
+            host = self.connection_info['host']
+        except KeyError:
+            host = self.connection_info['ip']
+            if not isinstance(host, (IPv4Address, IPv6Address)):
+                host = ip_address(host)
 
             # Properly format IPv6 URL if a v6 address is provided
-            if isinstance(ip, IPv6Address):
-                ip = f"[{ip.exploded}]"
+            if isinstance(host, IPv6Address):
+                host = f"[{host.exploded}]"
             else:
-                ip = ip.exploded
+                host = host.exploded
+
 
         if 'port' in self.connection_info:
             port = self.connection_info['port']
-            self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)
+            self.url = 'https://{host}:{port}/'.format(host=host, port=port)
         else:
-            self.url = 'https://{ip}/'.format(ip=ip)
+            self.url = 'https://{host}/'.format(host=host)
         login_url = '{f}v1/people/me'.format(f=self.url)
 
         self.token = get_token(self)
@@ -134,10 +134,10 @@ class Implementation(Imp):
         # Make sure it returned requests.codes.ok
         if response.status_code != requests.codes.ok:
             # Something bad happened
-            raise RequestException("Connection to '{ip}' has returned the "
+            raise RequestException("Connection to '{host}' has returned the "
                                    "following code '{c}', instead of the "
                                    "expected status code '{ok}'"\
-                                        .format(ip=ip, c=response.status_code,
+                                        .format(host=host, c=response.status_code,
                                                 ok=requests.codes.ok))
         self._is_connected = True
         log.info("Connected successfully to '{d}'".format(d=self.device.name))

--- a/src/rest/connector/libs/webex/implementation.py
+++ b/src/rest/connector/libs/webex/implementation.py
@@ -1,7 +1,9 @@
 import json
 import logging
-import requests
 
+from ipaddress import ip_address, IPv4Address, IPv6Address
+
+import requests
 from requests.exceptions import RequestException
 
 from pyats.connections import BaseConnection
@@ -96,6 +98,16 @@ class Implementation(Imp):
             ip = self.connection_info['host']
         else:
             ip = self.connection_info['ip'].exploded
+            ip = self.connection_info['ip']
+            if not isinstance(ip, (IPv4Address, IPv6Address)):
+                ip = ip_address(ip)
+
+            # Properly format IPv6 URL if a v6 address is provided
+            if isinstance(ip, IPv6Address):
+                ip = f"[{ip.exploded}]"
+            else:
+                ip = ip.exploded
+
         if 'port' in self.connection_info:
             port = self.connection_info['port']
             self.url = 'https://{ip}:{port}/'.format(ip=ip, port=port)

--- a/src/rest/connector/tests/test_apic_cobra.py
+++ b/src/rest/connector/tests/test_apic_cobra.py
@@ -22,6 +22,7 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['apic']
+        self.testbed_connection_names = ["cobra", "cobra-ipv6", "cobra-fqdn"]
 
         libs = get_installed_lib_versions()
         if not all(libs.values()) or len(set(libs.values())) != 1:
@@ -34,151 +35,172 @@ class test_rest_connector(unittest.TestCase):
     def test_init(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req().return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-            self.assertEqual(connection.device, self.device)
 
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.execute())
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.configure())
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req().return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+                    self.assertEqual(connection.device, self.device)
+
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.execute())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.configure())
 
     def test_connection(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-            self.assertEqual(connection.connected, False)
 
-        with patch('requests.post') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
-                'attributes': {'token': 'test',
-                               'version': 'test',
-                               'refreshTimeoutSeconds': 600
-                               }
-            }}]})
-            req.return_value = resp
-            connection.connect()
-            self.assertEqual(connection.connected, True)
-            connection.connect()
-            self.assertEqual(connection.connected, True)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+                    self.assertEqual(connection.connected, False)
 
-        # Now disconnect
-        with patch('requests.post') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.post') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
+                        'attributes': {'token': 'test',
+                                       'version': 'test',
+                                       'refreshTimeoutSeconds': 600
+                                       }
+                    }}]})
+                    req.return_value = resp
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+
+                # Now disconnect
+                with patch('requests.post') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_connection_wrong_code(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-        self.assertEqual(connection.connected, False)
 
-        with patch('requests.post') as req:
-            resp = Response()
-            resp.status_code = 404
-            req.return_value = resp
-            with self.assertRaises(HTTPError):
-                connection.connect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+                self.assertEqual(connection.connected, False)
 
-        self.assertEqual(connection.connected, False)
+                with patch('requests.post') as req:
+                    resp = Response()
+                    resp.status_code = 404
+                    req.return_value = resp
+                    with self.assertRaises(HTTPError):
+                        connection.connect()
 
-        # Now disconnect
-        with patch('requests.post') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                # Now disconnect
+                with patch('requests.post') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_attribute_call_not_connected(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-        with self.assertRaises(Exception):
-            connection.lookupByDn('uni')
+
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+                with self.assertRaises(Exception):
+                    connection.lookupByDn('uni')
 
     def test_attribute_call_connected(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-            self.assertEqual(connection.connected, False)
 
-            with patch('requests.post') as req, patch('requests.Session') as session:
-                resp = Response()
-                resp.status_code = 200
-                resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
-                    'attributes': {'token': 'test',
-                                   'version': 'test',
-                                   'refreshTimeoutSeconds': 600
-                                   }
-                }}]})
-                req.return_value = resp
-                connection.connect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+                    self.assertEqual(connection.connected, False)
 
-                resp._content = str.encode('<?xml version="1.0" ?><imdata totalCount="0"></imdata>')
-                session().get.return_value = resp
-                mo = connection.create(model='fv.Tenant',
-                                       parent_mo_or_dn='uni',
-                                       name='test')
-                connection.lookupByDn('uni')
-                connection.disconnect()
-            self.assertEqual(connection.connected, False)
+                    with patch('requests.post') as req, patch('requests.Session') as session:
+                        resp = Response()
+                        resp.status_code = 200
+                        resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
+                            'attributes': {'token': 'test',
+                                           'version': 'test',
+                                           'refreshTimeoutSeconds': 600
+                                           }
+                        }}]})
+                        req.return_value = resp
+                        connection.connect()
+
+                        resp._content = str.encode('<?xml version="1.0" ?><imdata totalCount="0"></imdata>')
+                        session().get.return_value = resp
+                        mo = connection.create(model='fv.Tenant',
+                                               parent_mo_or_dn='uni',
+                                               name='test')
+                        connection.lookupByDn('uni')
+                        connection.disconnect()
+                    self.assertEqual(connection.connected, False)
 
     def test_get_model_wrong_model_format(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
 
-        with self.assertRaises(NameError):
-            connection.get_model(model='wrong_model')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+
+                with self.assertRaises(NameError):
+                    connection.get_model(model='wrong_model')
 
     def test_get_model_wrong_model(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
 
-        with self.assertRaises(AttributeError):
-            connection.get_model(model='fv.Wrong')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+
+                with self.assertRaises(AttributeError):
+                    connection.get_model(model='fv.Wrong')
 
     def test_get_model(self):
         if not self.libs_present:
@@ -187,110 +209,125 @@ class test_rest_connector(unittest.TestCase):
         get_model is not dependant on connection,
         as it leverages the locally installed libraries
         '''
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
 
-        model = connection.get_model(model='fv.Tenant')
-        tenant_model = getattr(import_module(f'cobra.model.fv'), 'Tenant')
-        self.assertEqual(model, tenant_model)
+                self.assertEqual(connection.connected, False)
+
+                model = connection.get_model(model='fv.Tenant')
+                tenant_model = getattr(import_module(f'cobra.model.fv'), 'Tenant')
+                self.assertEqual(model, tenant_model)
 
     def test_config_and_commit_not_connected(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-        self.assertEqual(connection.connected, False)
-        with self.assertRaises(Exception):
-            mo = connection.create(model='fv.Tenant',
-                                   parent_mo_or_dn='uni',
-                                   name='test')
 
-            connection.config_and_commit(mo=mo)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
+
+                self.assertEqual(connection.connected, False)
+                with self.assertRaises(Exception):
+                    mo = connection.create(model='fv.Tenant',
+                                           parent_mo_or_dn='uni',
+                                           name='test')
+
+                    connection.config_and_commit(mo=mo)
 
     def test_config_and_commit_connected(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-        self.assertEqual(connection.connected, False)
 
-        with patch('requests.post') as req, patch('requests.Session') as session:
-            resp = Response()
-            resp.status_code = 200
-            resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
-                'attributes': {'token': 'test',
-                               'version': 'test',
-                               'refreshTimeoutSeconds': 600
-                               }
-            }}]})
-            req.return_value = resp
-            connection.connect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
 
-            resp.json = MagicMock(return_value={'imdata': []})
-            session().post.return_value = resp
-            mo = connection.create(model='fv.Tenant',
-                                   parent_mo_or_dn='uni',
-                                   name='test')
-            connection.config_and_commit(mo=mo)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.post') as req, patch('requests.Session') as session:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
+                        'attributes': {'token': 'test',
+                                       'version': 'test',
+                                       'refreshTimeoutSeconds': 600
+                                       }
+                    }}]})
+                    req.return_value = resp
+                    connection.connect()
+
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    session().post.return_value = resp
+                    mo = connection.create(model='fv.Tenant',
+                                           parent_mo_or_dn='uni',
+                                           name='test')
+                    connection.config_and_commit(mo=mo)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_config_and_commit_connected_wrong_status(self):
         if not self.libs_present:
             self.skipTest('Test skipped due to missing libraries')
-        with patch('requests.get') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
-                                       f'Python API {self.sdk_version} documentation</title>')
-            req.return_value = resp
-            connection = Acisdk(device=self.device, alias='cobra', via='cobra')
-        self.assertEqual(connection.connected, False)
 
-        with patch('requests.post') as req, patch('requests.Session') as session:
-            resp = Response()
-            resp.status_code = 200
-            resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
-                'attributes': {'token': 'test',
-                               'version': 'test',
-                               'refreshTimeoutSeconds': 600
-                               }
-            }}]})
-            req.return_value = resp
-            connection.connect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                with patch('requests.get') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp._content = str.encode('<title>Cisco APIC Python SDK Documentation &#8212; Cisco APIC '
+                                               f'Python API {self.sdk_version} documentation</title>')
+                    req.return_value = resp
+                    connection = Acisdk(device=self.device, alias='cobra', via=connection_name)
 
-            resp2 = Response()
-            resp2.status_code = 300
-            session().post.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.post') as req, patch('requests.Session') as session:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp.json = MagicMock(return_value={'imdata': [{'aaaLogin': {
+                        'attributes': {'token': 'test',
+                                       'version': 'test',
+                                       'refreshTimeoutSeconds': 600
+                                       }
+                    }}]})
+                    req.return_value = resp
+                    connection.connect()
 
-            with self.assertRaises(Exception):
-                mo = connection.create(model='fv.Tenant',
-                                       parent_mo_or_dn='uni',
-                                       name='test')
-                connection.config_and_commit(mo=mo)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    session().post.return_value = resp2
+
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(Exception):
+                        mo = connection.create(model='fv.Tenant',
+                                               parent_mo_or_dn='uni',
+                                               name='test')
+                        connection.config_and_commit(mo=mo)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
 
 if __name__ == '__main__':

--- a/src/rest/connector/tests/test_elasticsearch.py
+++ b/src/rest/connector/tests/test_elasticsearch.py
@@ -16,325 +16,383 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['elasticsearch']
+        self.testbed_connection_names = ["rest", "rest-ipv6", "rest-fqdn"]
 
     def test_init(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.device, self.device)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.execute())
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.configure())
+                self.assertEqual(connection.device, self.device)
+
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.execute())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.configure())
 
     def test_connection(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().get.return_value = resp
-            connection.connect()
-            self.assertEqual(connection.connected, True)
-            connection.connect()
-            self.assertEqual(connection.connected, True)
+                self.assertEqual(connection.connected, False)
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().get.return_value = resp
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(dn='temp', payload={'payload': 'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.post(dn='temp', payload={'payload': 'something'})
 
     def test_connection_wrong_code(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 404
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            with self.assertRaises(RequestException):
-                connection.connect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 404
+                    req().post.return_value = resp
 
-        self.assertEqual(connection.connected, False)
+                    with self.assertRaises(RequestException):
+                        connection.connect()
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(dn='temp', payload={'payload': 'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.post(dn='temp', payload={'payload': 'something'})
 
     def test_post_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().get.return_value = resp
-            req().post.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.post(dn='temp', payload={'payload': 'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().get.return_value = resp
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.post(dn='temp', payload={'payload': 'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp2
 
-            with self.assertRaises(RequestException):
-                connection.post(dn='temp', payload={'payload': 'something'})
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.post(dn='temp', payload={'payload': 'something'})
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.side_effect = [resp, resp, resp]
-            req().post.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.side_effect = [resp, resp, resp]
+                    req().post.return_value = resp2
 
-            connection.post(dn='temp', payload={'payload': 'something'})
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.post(dn='temp', payload={'payload': 'something'})
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().post.return_value = resp
-            req().get.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().post.return_value = resp
+                    req().get.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.post(dn='temp', payload={'payload': 'something'})
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.post(dn='temp', payload={'payload': 'something'})
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_get_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.get(dn='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.get(dn='temp')
 
     def test_get_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.get(dn='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.get(dn='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.get(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.get(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.side_effect = [resp, resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.side_effect = [resp, resp]
 
-            connection.get(dn='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.get(dn='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 500
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 500
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.get(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.get(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.delete(dn='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.delete(dn='temp')
 
     def test_delete_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().get.return_value = resp
-            req().delete.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.delete(dn='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().get.return_value = resp
+                    req().delete.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(dn='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.delete(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.delete(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().delete.return_value = resp2
-            req().get.return_value = resp
-            req().post.side_effect = [resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
-            connection.delete(dn='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().delete.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.side_effect = [resp, resp2]
 
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(dn='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().get.return_value = resp
-            req().post.return_value = resp
-            req().request.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().get.return_value = resp
+                    req().post.return_value = resp
+                    req().request.return_value = resp2
 
-            with self.assertRaises(RequestException):
-                connection.delete(dn='/temp')
+                    connection.connect()
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.delete(dn='/temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)

--- a/src/rest/connector/tests/test_iosxe.py
+++ b/src/rest/connector/tests/test_iosxe.py
@@ -6,6 +6,7 @@ __author__ = "Maaz Mashood Mohiuddin <mmashood@cisco.com>"
 
 import os
 import unittest
+from ipaddress import IPv6Address
 import requests_mock
 
 from pyats.topology import loader
@@ -14,71 +15,102 @@ from rest.connector import Rest
 
 HERE = os.path.dirname(__file__)
 
+def get_mock_server_address(testbed_device, connection_name):
+    # Test for IPv6, set the mocker URL accordingly
+    try:
+        destination_host = testbed_device.connections[connection_name].host
+    except AttributeError:
+        destination_host = testbed_device.connections[connection_name].ip
+        if isinstance(destination_host, IPv6Address):
+            destination_host = f"[{IPv6Address(destination_host).exploded}]"
+    return destination_host
+
+
 @requests_mock.Mocker(kw='mock')
 class test_iosxe_test_connector(unittest.TestCase):
-# @requests_mock.Mocker(kw='mock')
-# class test_iosxe_test_connector():
 
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['eWLC']
+        self.testbed_connection_names = ["rest", "rest-ipv6", "rest-fqdn"]
 
-    def test_connect(self, **kwargs):
-        connection = Rest(device=self.device, alias='rest', via='rest')
+    def generate_connection(self, **kwargs):
+        try:
+            connection_name = kwargs["connection_name"]
+        except KeyError:
+            connection_name = "rest"
+
+        connection = Rest(device=self.device, alias="rest", via=connection_name)
+
         response_text = """{
             "Cisco-IOS-XE-native:version": "17.3"
         }
         """
-        kwargs['mock'].get('https://198.51.100.3:443/restconf/data/Cisco-IOS-XE-native:native/version', text=response_text)
-        output = connection.connect(verbose=True).text
-        self.assertEqual(output, response_text)
+
+        # Set the mocker URL
+        destination_host = get_mock_server_address(self.device, connection_name)
+        kwargs['mock'].get(f'https://{destination_host}:443/restconf/data/Cisco-IOS-XE-native:native/version', text=response_text)
+        connection.connect(verbose=True)
         return connection
 
-    def test_get(self, **kwargs):
-        connection = self.test_connect()
-
+    def test_connect(self, **kwargs):
         response_text = """{
-    "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": [
-        {
-            "profile-name": "default-ap-profile",
-            "description": "default ap profile",
-            "hyperlocation": {
-                "pak-rssi-threshold-detection": -50
-            },
-            "halo-ble-entries": {
-                "halo-ble-entry": [
-                    {
-                        "beacon-id": 0
-                    },
-                    {
-                        "beacon-id": 1
-                    },
-                    {
-                        "beacon-id": 2
-                    },
-                    {
-                        "beacon-id": 3
-                    },
-                    {
-                        "beacon-id": 4
-                    }
-                ]
-            }
+            "Cisco-IOS-XE-native:version": "17.3"
         }
-    ]
-}
-"""
+        """
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+                self.assertEqual(connection.connected, True)
 
-        kwargs['mock'].get('https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile', text=response_text)
-        output = connection.get('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile', verbose=True).text
-        self.assertEqual(output, response_text)
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+    def test_get(self, **kwargs):
+        response_text = """{
+            "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": [
+                {
+                    "profile-name": "default-ap-profile",
+                    "description": "default ap profile",
+                    "hyperlocation": {
+                        "pak-rssi-threshold-detection": -50
+                    },
+                    "halo-ble-entries": {
+                        "halo-ble-entry": [
+                            {
+                                "beacon-id": 0
+                            },
+                            {
+                                "beacon-id": 1
+                            },
+                            {
+                                "beacon-id": 2
+                            },
+                            {
+                                "beacon-id": 3
+                            },
+                            {
+                                "beacon-id": 4
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        """
+
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                kwargs['mock'].get(f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile', text=response_text)
+                output = connection.get('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile', verbose=True).text
+                self.assertEqual(output, response_text)
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_post(self, **kwargs):
-        connection = self.test_connect()
-
         payload = """
         {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -110,17 +142,22 @@ class test_iosxe_test_connector(unittest.TestCase):
     }
 }
 """
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].post(url, status_code=204)
-        output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
-        self.assertEqual(output, '')
-        connection.disconnect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
 
-        self.assertEqual(connection.connected, False)
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].post(url, status_code=204)
+                output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
+                self.assertEqual(output, '')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
 
     def test_post_dict_payload_without_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -153,18 +190,23 @@ class test_iosxe_test_connector(unittest.TestCase):
 }
         response_text = ""
 
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].post(url, text=response_text)
-        try:
-            output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
 
-        self.assertEqual(connection.connected, False)
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].post(url, text=response_text)
+                try:
+                    output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_post_dict_payload_with_json_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -195,18 +237,24 @@ class test_iosxe_test_connector(unittest.TestCase):
         }
     }
 }
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].post(url, status_code=204)
-        try:
-            output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].post(url, status_code=204)
+                try:
+                    output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_post_dict_payload_with_xml_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -237,19 +285,25 @@ class test_iosxe_test_connector(unittest.TestCase):
         }
     }
 }
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].post(url, status_code=204)
-        try:
-            output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='xml', verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].post(url, status_code=204)
+                try:
+                    output = connection.post('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='xml', verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
 
     def test_patch(self, **kwargs):
-        connection = self.test_connect()
 
         payload = """{
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -279,17 +333,23 @@ class test_iosxe_test_connector(unittest.TestCase):
     }
 }
 """
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
-        kwargs['mock'].patch(url, status_code=204)
-        output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='json', verbose=True).text
-        self.assertEqual(output, '')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+                kwargs['mock'].patch(url, status_code=204)
+                output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='json', verbose=True).text
+                self.assertEqual(output, '')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
 
     def test_patch_dict_payload_without_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -320,18 +380,23 @@ class test_iosxe_test_connector(unittest.TestCase):
 }
         response_text = ""
 
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
-        kwargs['mock'].patch(url, text=response_text)
-        try:
-            output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
 
-        self.assertEqual(connection.connected, False)
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+                kwargs['mock'].patch(url, text=response_text)
+                try:
+                    output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_patch_dict_payload_with_json_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -362,18 +427,24 @@ class test_iosxe_test_connector(unittest.TestCase):
         }
     }
 }
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
-        kwargs['mock'].patch(url, status_code=204)
-        try:
-            output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='json', verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+                kwargs['mock'].patch(url, status_code=204)
+                try:
+                    output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='json', verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_patch_dict_payload_with_xml_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -402,19 +473,25 @@ class test_iosxe_test_connector(unittest.TestCase):
         }
     }
 }
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
-        kwargs['mock'].patch(url, status_code=204)
-        try:
-            output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='xml', verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile'
+                kwargs['mock'].patch(url, status_code=204)
+                try:
+                    output = connection.patch('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=default-ap-profile', payload, content_type='xml', verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
 
     def test_put(self, **kwargs):
-        connection = self.test_connect()
 
         payload = """{
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -446,17 +523,23 @@ class test_iosxe_test_connector(unittest.TestCase):
     }
 }
 """
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].put(url, status_code=204)
-        output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
-        self.assertEqual(output, '')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].put(url, status_code=204)
+                output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
+                self.assertEqual(output, '')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
 
     def test_put_dict_payload_without_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -489,18 +572,23 @@ class test_iosxe_test_connector(unittest.TestCase):
 }
         response_text = ""
 
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].put(url, text=response_text)
-        try:
-            output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
 
-        self.assertEqual(connection.connected, False)
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].put(url, text=response_text)
+                try:
+                    output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_put_dict_payload_with_json_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -531,18 +619,24 @@ class test_iosxe_test_connector(unittest.TestCase):
         }
     }
 }
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].put(url, status_code=204)
-        try:
-            output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].put(url, status_code=204)
+                try:
+                    output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='json', verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_put_dict_payload_with_xml_content_type(self, **kwargs):
-        connection = self.test_connect()
 
         payload = {
     "Cisco-IOS-XE-wireless-site-cfg:ap-cfg-profile": {
@@ -573,27 +667,38 @@ class test_iosxe_test_connector(unittest.TestCase):
         }
     }
 }
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles'
-        kwargs['mock'].put(url, status_code=204)
-        try:
-            output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='xml', verbose=True).text
-        except AssertionError as e:
-            self.assertEqual(str(e), 'content_type parameter required when passing dict')
-        connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
+
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles'
+                kwargs['mock'].put(url, status_code=204)
+                try:
+                    output = connection.put('/restconf/data/site-cfg-data/ap-cfg-profiles', payload, content_type='xml', verbose=True).text
+                except AssertionError as e:
+                    self.assertEqual(str(e), 'content_type parameter required when passing dict')
+                connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
 
     def test_delete(self, **kwargs):
-        connection = self.test_connect()
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = self.generate_connection(connection_name=connection_name, **kwargs)
 
-        url = 'https://198.51.100.3:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=test-profile'
-        kwargs['mock'].delete(url, status_code=204)
-        output = connection.delete('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=test-profile', verbose=True).text
-        self.assertEqual(output, '')
-        connection.disconnect()
+                # Set the mocker URL
+                destination_host = get_mock_server_address(self.device, connection_name)
+                url = f'https://{destination_host}:443/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=test-profile'
+                kwargs['mock'].delete(url, status_code=204)
+                output = connection.delete('/restconf/data/site-cfg-data/ap-cfg-profiles/ap-cfg-profile=test-profile', verbose=True).text
+                self.assertEqual(output, '')
+                connection.disconnect()
 
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
 
 
 if __name__ == "__main__":

--- a/src/rest/connector/tests/test_ise.py
+++ b/src/rest/connector/tests/test_ise.py
@@ -15,34 +15,39 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['ise']
+        self.testbed_connection_names = ["rest", "rest-ipv6", "rest-fqdn"]
 
     def test_init(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.device, self.device)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+                self.assertEqual(connection.device, self.device)
 
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.execute())
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.configure())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.execute())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.configure())
 
     def test_connection(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+                self.assertEqual(connection.connected, False)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.headers['Content-type'] = 'application/json'
-            resp.status_code = 200
-            resp._content = b'{"OperationResult": {"resultValue": [{"value": "3.3.0.430",' + \
-                            b' "name": "version"}, {"value": "0", "name": "patch information"}]}}'
-            req().request.return_value = resp
-            connection.connect()
-            self.assertEqual(connection.connected, True)
-            connection.connect()
-            self.assertEqual(connection.connected, True)
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.headers['Content-type'] = 'application/json'
+                    resp.status_code = 200
+                    resp._content = b'{"OperationResult": {"resultValue": [{"value": "3.3.0.430",' + \
+                                    b' "name": "version"}, {"value": "0", "name": "patch information"}]}}'
+                    req().request.return_value = resp
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
 
-        # Now disconnect
-        with patch('requests.session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                # Now disconnect
+                with patch('requests.session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 

--- a/src/rest/connector/tests/test_nd.py
+++ b/src/rest/connector/tests/test_nd.py
@@ -18,6 +18,7 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['nd']
+        self.testbed_connection_names = ["rest", "rest-ipv6", "rest-fqdn"]
         # Always mock logging
         mock_logger = patch(
             "rest.connector.libs.nd.implementation.log"
@@ -26,529 +27,622 @@ class test_rest_connector(unittest.TestCase):
         self.addCleanup(mock_logger.stop)
 
     def test_init(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.device, self.device)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.execute())
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.configure())
+                self.assertEqual(connection.device, self.device)
+
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.execute())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.configure())
 
     def test_connection(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            self.assertEqual(connection.connected, True)
-            connection.connect()
-            self.assertEqual(connection.connected, True)
+                self.assertEqual(connection.connected, False)
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_connection_wrong_code(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = [404, 404, 404]
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            with self.assertRaises(ConnectionError):
-                connection.connect(retry_wait=1)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = [404, 404, 404]
+                    req().post.return_value = resp
 
-        self.assertEqual(connection.connected, False)
+                    with self.assertRaises(ConnectionError):
+                        connection.connect(retry_wait=1)
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(api_url='temp', payload={'payload':'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.post(api_url='temp', payload={'payload':'something'})
 
     def test_post_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.post(api_url='temp', payload={'payload':'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.post(api_url='temp', payload={'payload':'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp2, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp2, resp, resp2]
 
-            with self.assertRaises(RequestException):
-                connection.post(api_url='temp', payload={'payload':'something'})
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.post(api_url='temp', payload={'payload':'something'})
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp2]
 
-            connection.post(api_url='temp', payload={'payload':'something'},
-                            expected_status_code=300)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.post(api_url='temp', payload={'payload':'something'},
+                                    expected_status_code=300)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp2, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp2, resp, resp2]
 
-            with self.assertRaises(RequestException):
-                connection.post(api_url='temp', payload={'payload':'something'},
-                                expected_status_code=400)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.post(api_url='temp', payload={'payload':'something'},
+                                        expected_status_code=400)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_xml_dict_payload_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
+                self.assertEqual(connection.connected, False)
 
-            with self.assertRaises(ValueError):
-                connection.post(api_url='temp', content_type='xml',
-                                payload={'payload': 'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(ValueError):
+                        connection.post(api_url='temp', content_type='xml',
+                                        payload={'payload': 'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_xml_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            resp._content = '<?xml version="1.0" encoding="UTF-8"?>' \
-                            '<imdata totalCount="0"></imdata>'
+                self.assertEqual(connection.connected, False)
 
-            connection.post(api_url='temp', content_type='xml',
-                            payload='<fvTenant name="ExampleCorp"/>')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp._content = '<?xml version="1.0" encoding="UTF-8"?>' \
+                                    '<imdata totalCount="0"></imdata>'
+
+                    connection.post(api_url='temp', content_type='xml',
+                                    payload='<fvTenant name="ExampleCorp"/>')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_form_dict_payload_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().put.text = 'Operation is successful'
-            connection.connect()
+                self.assertEqual(connection.connected, False)
 
-            connection.post(api_url='temp', content_type='form',
-                            payload={'payload': 'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().put.text = 'Operation is successful'
+                    connection.connect()
+
+                    connection.post(api_url='temp', content_type='form',
+                                    payload={'payload': 'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_form_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().put.text = 'Operation is successful'
-            connection.connect()
+                self.assertEqual(connection.connected, False)
 
-            connection.post(api_url='temp', content_type='form',
-                            payload='Form%20Data')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().put.text = 'Operation is successful'
+                    connection.connect()
+
+                    connection.post(api_url='temp', content_type='form',
+                                    payload='Form%20Data')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.put(api_url='temp', payload={'payload':'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.put(api_url='temp', payload={'payload':'something'})
 
     def test_put_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().put.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.put(api_url='temp', payload={'payload':'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().put.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.put(api_url='temp', payload={'payload':'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().put.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().put.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-            with self.assertRaises(RequestException):
-                connection.put(api_url='temp', payload={'payload':'something'})
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.put(api_url='temp', payload={'payload':'something'})
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().put.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().put.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-            connection.put(api_url='temp', payload={'payload':'something'},
-                           expected_status_code=300)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.put(api_url='temp', payload={'payload':'something'},
+                                   expected_status_code=300)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().put.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().put.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-            with self.assertRaises(RequestException):
-                connection.put(api_url='temp', payload={'payload':'something'},
-                               expected_status_code=400)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.put(api_url='temp', payload={'payload':'something'},
+                                       expected_status_code=400)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_xml_dict_payload_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().put.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
+                self.assertEqual(connection.connected, False)
 
-            with self.assertRaises(ValueError):
-                connection.put(api_url='temp', content_type='xml',
-                               payload={'payload': 'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().put.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(ValueError):
+                        connection.put(api_url='temp', content_type='xml',
+                                       payload={'payload': 'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_xml_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().put.return_value = resp
-            connection.connect()
-            resp._content = '<?xml version="1.0" encoding="UTF-8"?>' \
-                            '<imdata totalCount="0"></imdata>'
+                self.assertEqual(connection.connected, False)
 
-            connection.put(api_url='temp', content_type='xml',
-                           payload='<fvTenant name="ExampleCorp"/>')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().put.return_value = resp
+                    connection.connect()
+                    resp._content = '<?xml version="1.0" encoding="UTF-8"?>' \
+                                    '<imdata totalCount="0"></imdata>'
+
+                    connection.put(api_url='temp', content_type='xml',
+                                   payload='<fvTenant name="ExampleCorp"/>')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_form_dict_payload_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().put.return_value = resp
-            req().put.text = 'Operation is successful'
-            connection.connect()
+                self.assertEqual(connection.connected, False)
 
-            connection.put(api_url='temp', content_type='form',
-                           payload={'payload': 'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().put.return_value = resp
+                    req().put.text = 'Operation is successful'
+                    connection.connect()
+
+                    connection.put(api_url='temp', content_type='form',
+                                   payload={'payload': 'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_put_form_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().put.return_value = resp
-            req().put.text = 'Operation is successful'
-            connection.connect()
+                self.assertEqual(connection.connected, False)
 
-            connection.put(api_url='temp', content_type='form',
-                           payload='Form%20Data')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().put.return_value = resp
+                    req().put.text = 'Operation is successful'
+                    connection.connect()
+
+                    connection.put(api_url='temp', content_type='form',
+                                   payload='Form%20Data')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.get(api_url='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.get(api_url='temp')
 
     def test_get_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.get(api_url='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.get(api_url='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-            with self.assertRaises(RequestException):
-                connection.get(api_url='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.get(api_url='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-            connection.get(api_url='temp', expected_status_code=300)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.get(api_url='temp', expected_status_code=300)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-            with self.assertRaises(RequestException):
-                connection.get(api_url='temp', expected_status_code=400)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.get(api_url='temp', expected_status_code=400)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.delete(api_url='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.delete(api_url='temp')
 
     def test_delete_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().delete.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.delete(api_url='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().delete.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(api_url='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
+                self.assertEqual(connection.connected, False)
 
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().delete.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
 
-            with self.assertRaises(RequestException):
-                connection.delete(api_url='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().delete.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.delete(api_url='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().delete.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
-            connection.delete(api_url='temp', expected_status_code=300)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().delete.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(api_url='temp', expected_status_code=300)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().delete.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().delete.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
 
-            with self.assertRaises(RequestException):
-                connection.delete(api_url='temp', expected_status_code=400)
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    with self.assertRaises(RequestException):
+                        connection.delete(api_url='temp', expected_status_code=400)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
 
 if __name__ == '__main__':

--- a/src/rest/connector/tests/test_nxos.py
+++ b/src/rest/connector/tests/test_nxos.py
@@ -18,374 +18,438 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['PE1']
+        self.testbed_connection_names = ["rest", "rest-ipv6", "rest-fqdn"]
 
     def test_init(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.device, self.device)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.execute())
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.configure())
+                self.assertEqual(connection.device, self.device)
+
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.execute())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.configure())
 
     def test_connection(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            self.assertEqual(connection.connected, True)
-            connection.connect()
-            self.assertEqual(connection.connected, True)
+                self.assertEqual(connection.connected, False)
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(dn='temp', payload={'payload':'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.post(dn='temp', payload={'payload':'something'})
 
     def test_connection_wrong_code(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 404
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            with self.assertRaises(RequestException):
-                connection.connect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 404
+                    req().post.return_value = resp
 
-        self.assertEqual(connection.connected, False)
+                    with self.assertRaises(RequestException):
+                        connection.connect()
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
 
     def test_post_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.post(dn='temp', payload={'payload':'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.post(dn='temp', payload={'payload':'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().post.side_effect = [resp, resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().post.side_effect = [resp, resp]
 
-            with self.assertRaises(RequestException):
-                connection.post(dn='temp', payload={'payload':'something'})
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.post(dn='temp', payload={'payload':'something'})
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2, resp2]
+
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
 
 
 
-            connection.post(dn='temp', payload={'payload':'something'})
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.post(dn='temp', payload={'payload':'something'})
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().post.side_effect = [resp, resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().post.side_effect = [resp, resp]
 
-            with self.assertRaises(RequestException):
-                connection.post(dn='temp', payload={'payload':'something'})
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.post(dn='temp', payload={'payload':'something'})
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_get_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.get(dn='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.get(dn='temp')
 
     def test_get_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.get(dn='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.get(dn='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().post.side_effect = [resp, resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().post.side_effect = [resp, resp]
 
-            with self.assertRaises(RequestException):
-                connection.get(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.get(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
+
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
 
 
-            connection.get(dn='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.get(dn='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 500
-            req().request.return_value = resp2
-            req().post.side_effect = [resp, resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 500
+                    req().request.return_value = resp2
+                    req().post.side_effect = [resp, resp]
 
-            with self.assertRaises(RequestException):
-                connection.get(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.get(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.delete(dn='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.delete(dn='temp')
 
     def test_delete_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().delete.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.delete(dn='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().delete.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(dn='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().post.side_effect = [resp, resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().post.side_effect = [resp, resp]
 
-            with self.assertRaises(RequestException):
-                connection.delete(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.delete(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().delete.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
-            connection.delete(dn='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().delete.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
+
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(dn='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
 
 
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().post.side_effect = [resp, resp]
-            req().request.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().post.side_effect = [resp, resp]
+                    req().request.return_value = resp2
 
-            with self.assertRaises(RequestException):
-                connection.delete(dn='/temp')
+                    connection.connect()
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.delete(dn='/temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_request_exception_retry(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.side_effect = [resp, resp]
-            req().request.side_effect = [TimeoutError('Timeout'), resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.side_effect = [resp, resp]
+                    req().request.side_effect = [TimeoutError('Timeout'), resp]
 
-            with self.assertLogs(logger='rest.connector.libs.nxos.implementation', level=logging.INFO) as log_cm:
-                connection.post(dn='temp', payload={'payload': 'something'}, retry_wait=0)
-                self.assertIn('TimeoutError',
-                              '\n'.join(log_cm.output))
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertLogs(logger='rest.connector.libs.nxos.implementation', level=logging.INFO) as log_cm:
+                        connection.post(dn='temp', payload={'payload': 'something'}, retry_wait=0)
+                        self.assertIn('TimeoutError',
+                                      '\n'.join(log_cm.output))
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_headers(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.post(
-                dn='temp', payload={'payload': 'something'}, headers='str'
-            )
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.post(
+                        dn='temp', payload={'payload': 'something'}, headers='str'
+                    )
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_response(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            self.assertEqual(connection.connected, True)
+                self.assertEqual(connection.connected, False)
 
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    self.assertEqual(connection.connected, True)
+
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)

--- a/src/rest/connector/tests/test_viptela.py
+++ b/src/rest/connector/tests/test_viptela.py
@@ -18,166 +18,200 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['vmanage']
+        self.testbed_connection_names = ["rest", "rest-ipv6", "rest-fqdn"]
 
     def test_init(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.device, self.device)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.execute())
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.configure())
+                self.assertEqual(connection.device, self.device)
+
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.execute())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.configure())
 
     def test_connection(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            connection.connect()
-            self.assertEqual(connection.connected, True)
-            connection.connect()
-            self.assertEqual(connection.connected, True)
+                self.assertEqual(connection.connected, False)
 
-        # Now disconnect
-        with patch('requests.session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+
+                # Now disconnect
+                with patch('requests.session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(mount_point='temp',
-                            payload={'payload': 'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.post(mount_point='temp',
+                                    payload={'payload': 'something'})
 
     def test_connection_wrong_code(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.status_code = 404
-            req().post.return_value = resp
-            req().get.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            with self.assertRaises(RequestException):
-                connection.connect()
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.status_code = 404
+                    req().post.return_value = resp
+                    req().get.return_value = resp
 
-        self.assertEqual(connection.connected, False)
+                    with self.assertRaises(RequestException):
+                        connection.connect()
 
-        # Now disconnect
-        with patch('requests.session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                # Now disconnect
+                with patch('requests.session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.raw = MagicMock()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.post(mount_point='temp',
-                            payload={'payload': 'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.raw = MagicMock()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.post(mount_point='temp',
+                                    payload={'payload': 'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.get(mount_point='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.get(mount_point='temp')
 
     def test_get_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.raw = MagicMock()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.get(mount_point='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.raw = MagicMock()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.get(mount_point='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.raw = MagicMock()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.raw = MagicMock()
-            resp2.status_code = 300
-            req().get.side_effect = [resp, resp2]
-            req().post.side_effect = [resp, resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.raw = MagicMock()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.raw = MagicMock()
+                    resp2.status_code = 300
+                    req().get.side_effect = [resp, resp2]
+                    req().post.side_effect = [resp, resp, resp2]
 
-            connection.get(mount_point='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.get(mount_point='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.delete(mount_point='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.delete(mount_point='temp')
 
     def test_delete_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.raw = MagicMock()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            req().delete.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.delete(mount_point='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.raw = MagicMock()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    req().delete.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(mount_point='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.session') as req:
-            resp = Response()
-            resp.raw = MagicMock()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.raw = MagicMock()
-            resp2.status_code = 300
-            req().delete.return_value = resp2
-            req().post.side_effect = [resp, resp, resp2]
-            req().get.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
-            connection.delete(mount_point='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
-        self.assertEqual(connection.connected, False)
+                with patch('requests.session') as req:
+                    resp = Response()
+                    resp.raw = MagicMock()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.raw = MagicMock()
+                    resp2.status_code = 300
+                    req().delete.return_value = resp2
+                    req().post.side_effect = [resp, resp, resp2]
+                    req().get.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(mount_point='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
 
 if __name__ == '__main__':

--- a/src/rest/connector/tests/test_webex.py
+++ b/src/rest/connector/tests/test_webex.py
@@ -16,325 +16,383 @@ class test_rest_connector(unittest.TestCase):
     def setUp(self):
         self.testbed = loader.load(os.path.join(HERE, 'testbed.yaml'))
         self.device = self.testbed.devices['webex']
+        self.testbed_connection_names = ["rest", "rest-ipv6", "rest-fqdn"]
 
     def test_init(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.device, self.device)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.execute())
-        with self.assertRaises(NotImplementedError):
-            self.assertRaises(connection.configure())
+                self.assertEqual(connection.device, self.device)
+
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.execute())
+                with self.assertRaises(NotImplementedError):
+                    self.assertRaises(connection.configure())
 
     def test_connection(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().get.return_value = resp
-            connection.connect()
-            self.assertEqual(connection.connected, True)
-            connection.connect()
-            self.assertEqual(connection.connected, True)
+                self.assertEqual(connection.connected, False)
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().get.return_value = resp
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+                    connection.connect()
+                    self.assertEqual(connection.connected, True)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(dn='temp', payload={'payload': 'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.post(dn='temp', payload={'payload': 'something'})
 
     def test_connection_wrong_code(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 404
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            with self.assertRaises(RequestException):
-                connection.connect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 404
+                    req().post.return_value = resp
 
-        self.assertEqual(connection.connected, False)
+                    with self.assertRaises(RequestException):
+                        connection.connect()
 
-        # Now disconnect
-        with patch('requests.Session') as req:
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                # Now disconnect
+                with patch('requests.Session') as req:
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.post(dn='temp', payload={'payload': 'something'})
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.post(dn='temp', payload={'payload': 'something'})
 
     def test_post_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().get.return_value = resp
-            req().post.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.post(dn='temp', payload={'payload': 'something'})
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().get.return_value = resp
+                    req().post.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.post(dn='temp', payload={'payload': 'something'})
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp2
 
-            with self.assertRaises(RequestException):
-                connection.post(dn='temp', payload={'payload': 'something'})
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.post(dn='temp', payload={'payload': 'something'})
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.side_effect = [resp, resp, resp]
-            req().post.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.side_effect = [resp, resp, resp]
+                    req().post.return_value = resp2
 
-            connection.post(dn='temp', payload={'payload': 'something'})
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.post(dn='temp', payload={'payload': 'something'})
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_post_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().post.return_value = resp
-            req().get.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().post.return_value = resp
+                    req().get.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.post(dn='temp', payload={'payload': 'something'})
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.post(dn='temp', payload={'payload': 'something'})
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_get_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.get(dn='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.get(dn='temp')
 
     def test_get_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().post.return_value = resp
-            req().get.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.get(dn='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().post.return_value = resp
+                    req().get.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.get(dn='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.get(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.get(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().get.side_effect = [resp, resp]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().get.side_effect = [resp, resp]
 
-            connection.get(dn='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+
+                    connection.get(dn='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_get_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 500
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 500
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.get(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.get(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_not_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        with self.assertRaises(Exception):
-            connection.delete(dn='temp')
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
+
+                with self.assertRaises(Exception):
+                    connection.delete(dn='temp')
 
     def test_delete_connected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            req().get.return_value = resp
-            req().delete.return_value = resp
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            connection.delete(dn='temp')
-            connection.disconnect()
-        self.assertEqual(connection.connected, False)
+                self.assertEqual(connection.connected, False)
+
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    req().get.return_value = resp
+                    req().delete.return_value = resp
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(dn='temp')
+                    connection.disconnect()
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().request.return_value = resp2
-            req().get.return_value = resp
-            req().post.return_value = resp
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().request.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.return_value = resp
 
-            with self.assertRaises(RequestException):
-                connection.delete(dn='temp')
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.delete(dn='temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 300
-            req().delete.return_value = resp2
-            req().get.return_value = resp
-            req().post.side_effect = [resp, resp2]
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
-            resp.json = MagicMock(return_value={'imdata': []})
-            resp2.json = MagicMock(return_value={'imdata': []})
-            connection.delete(dn='temp')
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 300
+                    req().delete.return_value = resp2
+                    req().get.return_value = resp
+                    req().post.side_effect = [resp, resp2]
 
-        self.assertEqual(connection.connected, False)
+                    connection.connect()
+                    resp.json = MagicMock(return_value={'imdata': []})
+                    resp2.json = MagicMock(return_value={'imdata': []})
+                    connection.delete(dn='temp')
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)
 
     def test_delete_connected_wrong_status_change_expected(self):
-        connection = Rest(device=self.device, alias='rest', via='rest')
-        self.assertEqual(connection.connected, False)
+        for connection_name in self.testbed_connection_names:
+            with self.subTest(connection_name=connection_name):
+                connection = Rest(device=self.device, alias='rest', via=connection_name)
 
-        with patch('requests.Session') as req:
-            resp = Response()
-            resp.status_code = 200
-            resp2 = Response()
-            resp2.status_code = 400
-            req().get.return_value = resp
-            req().post.return_value = resp
-            req().request.return_value = resp2
+                self.assertEqual(connection.connected, False)
 
-            connection.connect()
+                with patch('requests.Session') as req:
+                    resp = Response()
+                    resp.status_code = 200
+                    resp2 = Response()
+                    resp2.status_code = 400
+                    req().get.return_value = resp
+                    req().post.return_value = resp
+                    req().request.return_value = resp2
 
-            with self.assertRaises(RequestException):
-                connection.delete(dn='/temp')
+                    connection.connect()
 
-            self.assertEqual(connection.connected, True)
-            connection.disconnect()
+                    with self.assertRaises(RequestException):
+                        connection.delete(dn='/temp')
 
-        self.assertEqual(connection.connected, False)
+                    self.assertEqual(connection.connected, True)
+                    connection.disconnect()
+
+                self.assertEqual(connection.connected, False)

--- a/src/rest/connector/tests/testbed.yaml
+++ b/src/rest/connector/tests/testbed.yaml
@@ -10,6 +10,13 @@ devices:
       rest:
         class: rest.connector.Rest
         ip: 198.51.100.1
+      rest-ipv6:
+        class: rest.connector.Rest
+        ip: 2001:db8:c15:c0::64:1
+      rest-fqdn:
+        class: rest.connector.Rest
+        host: test-nxos.example.com
+
   ncs:
       os: nso
       type: nso
@@ -24,6 +31,21 @@ devices:
           port: 8080
           username: cisco
           password: cisco
+        rest-ipv6:
+          class: rest.connector.Rest
+          protocol: http
+          ip: 2001:db8:c15:c0::64:2
+          port: 8080
+          username: cisco
+          password: cisco
+        rest-fqdn:
+          class: rest.connector.Rest
+          protocol: http
+          host: test-ncs.example.com
+          port: 8080
+          username: cisco
+          password: cisco
+
   eWLC:
         os: iosxe
         type: eWLC
@@ -38,6 +60,21 @@ devices:
             port: 443
             username: cisco
             password: cisco
+          rest-ipv6:
+            class: rest.connector.Rest
+            protocol: https
+            ip: 2001:db8:c15:c0::64:3
+            port: 443
+            username: cisco
+            password: cisco
+          rest-fqdn:
+            class: rest.connector.Rest
+            protocol: https
+            host: test-ewlc.example.com
+            port: 443
+            username: cisco
+            password: cisco
+
   apic:
       os: apic
       type: apic
@@ -51,11 +88,34 @@ devices:
           ip: 198.51.100.4
           username: cisco
           password: cisco
+        rest-ipv6:
+          class: rest.connector.Rest
+          protocol: http
+          ip: 2001:db8:c15:c0::64:4
+          username: cisco
+          password: cisco
+        rest-fqdn:
+          class: rest.connector.Rest
+          protocol: http
+          host: test-apic.example.com
+          username: cisco
+          password: cisco
         cobra:
           class: rest.connector.Acisdk
           ip: 198.51.100.5
           username: cisco
           password: cisco
+        cobra-ipv6:
+          class: rest.connector.Acisdk
+          ip: 2001:db8:c15:c0::64:5
+          username: cisco
+          password: cisco
+        cobra-fqdn:
+          class: rest.connector.Acisdk
+          host: test-apic-cobra.example.com
+          username: cisco
+          password: cisco
+
   nd:
     os: nd
     type: linux
@@ -69,6 +129,19 @@ devices:
         ip: 198.51.100.6
         username: cisco
         password: cisco
+      rest-ipv6:
+        class: rest.connector.Rest
+        protocol: http
+        ip: 2001:db8:c15:c0::64:6
+        username: cisco
+        password: cisco
+      rest-fqdn:
+        class: rest.connector.Rest
+        protocol: http
+        host: test-nd.example.com
+        username: cisco
+        password: cisco
+
   bigip01.lab.local:
     alias: 'bigip01'
     type: 'bigip'
@@ -85,6 +158,7 @@ devices:
           rest:
             username: admin
             password: admin
+
   vmanage:
       os:        viptela
       type:      vmanage
@@ -100,6 +174,23 @@ devices:
             rest:
               username: admin
               password: admin
+        rest-ipv6:
+          class: rest.connector.Rest
+          protocol: http
+          ip: 2001:db8:c15:c0::64:8
+          credentials:
+            rest:
+              username: admin
+              password: admin
+        rest-fqdn:
+          class: rest.connector.Rest
+          protocol: http
+          host: test-vmanage.example.com
+          credentials:
+            rest:
+              username: admin
+              password: admin
+
   webex:
     os: webex
     type: webex
@@ -114,6 +205,21 @@ devices:
         credentials:
           rest:
             token: webexaccesstoken
+      rest-ipv6:
+        class: rest.connector.Rest
+        protocol: http
+        ip: 2001:db8:c15:c0::64:9
+        credentials:
+          rest:
+            token: webexaccesstoken
+      rest-fqdn:
+        class: rest.connector.Rest
+        protocol: http
+        host: test-webex.example.com
+        credentials:
+          rest:
+            token: webexaccesstoken
+
   xpresso:
     os: xpresso
     type: xpresso
@@ -128,6 +234,7 @@ devices:
         credentials:
           rest:
             token: xpressoaccesstoken
+
   elasticsearch:
     os: elasticsearch
     type: elasticsearch
@@ -139,6 +246,17 @@ devices:
         ip: 198.51.100.10
         port: 9200
         protocol: http
+      rest-ipv6:
+        class: rest.connector.Rest
+        ip: 2001:db8:c15:c0::64:a
+        port: 9200
+        protocol: http
+      rest-fqdn:
+        class: rest.connector.Rest
+        host: test-elasticsearch.example.com
+        port: 9200
+        protocol: http
+
   ise:
     os: ise
     connections:
@@ -147,6 +265,16 @@ devices:
       rest:
         class: rest.connector.Rest
         ip: 127.0.0.2
+        port: 9000
+        protocol: http
+      rest-ipv6:
+        class: rest.connector.Rest
+        ip: 2001:db8:c15:c0::64:b
+        port: 9000
+        protocol: http
+      rest-fqdn:
+        class: rest.connector.Rest
+        host: test-ise.example.com
         port: 9000
         protocol: http
 


### PR DESCRIPTION
 following PR #91 (https://github.com/CiscoTestAutomation/rest/pull/91)

This PR enables the rest.connector to connect to a device when the Host: header is required because the device is not reachable directly by IP address (for example, via reverse proxy)