### PR TITLE
Release 26.7

### DIFF
--- a/docs/changelog/2026/july.rst
+++ b/docs/changelog/2026/july.rst
@@ -1,0 +1,18 @@
+July 2026
+==========
+
+July 28 - Rest v26.7
+--------------------
+
+
+
+.. csv-table:: New Module Versions
+    :header: "Modules", "Version"
+
+    ``rest.connector``, v26.7
+
+
+
+
+Changelogs
+^^^^^^^^^^

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -4,6 +4,7 @@ Changelog
 .. toctree::
    :maxdepth: 2
 
+   2026/july
    2026/june
    2026/may
    2026/april

--- a/src/rest/connector/__init__.py
+++ b/src/rest/connector/__init__.py
@@ -2,7 +2,7 @@
 the device via REST api"""
 
 # metadata
-__version__ = "26.6"
+__version__ = "26.7"
 __author__ = ['Jean-Benoit Aubin <jeaubin@cisco.com>',
               'Takashi Higashimura (tahigash) <tahigash@cisco.com>']
 


### PR DESCRIPTION
## Summary

Prepare the repository for pyATS Release 26.7.

## Validation

- `release_26.7` is pushed to the remote.
- The release branch contains changes relative to `main`.
- This PR targets `main`.